### PR TITLE
Look at .tdata when computing TLS image size

### DIFF
--- a/interpreter/customlabels/customlabels.go
+++ b/interpreter/customlabels/customlabels.go
@@ -31,7 +31,7 @@ type data struct {
 
 var _ interpreter.Data = &data{}
 
-func roundUp(multiple uint64, value uint64) uint64 {
+func roundUp(multiple, value uint64) uint64 {
 	if multiple == 0 {
 		return value
 	}
@@ -87,7 +87,8 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 			// of the image. So we need to find the size of the image in order to know where the
 			// beginning is.
 			//
-			// The image is just .tdata followed by .tbss, but we also have to respect the alignment.
+			// The image is just .tdata followed by .tbss,
+            // but we also have to respect the alignment.
 			tbss, err := ef.Tbss()
 			if err != nil {
 				return nil, err

--- a/interpreter/customlabels/customlabels.go
+++ b/interpreter/customlabels/customlabels.go
@@ -88,7 +88,7 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 			// beginning is.
 			//
 			// The image is just .tdata followed by .tbss,
-            // but we also have to respect the alignment.
+			// but we also have to respect the alignment.
 			tbss, err := ef.Tbss()
 			if err != nil {
 				return nil, err

--- a/libpf/pfelf/file.go
+++ b/libpf/pfelf/file.go
@@ -57,6 +57,12 @@ var ErrSymbolNotFound = errors.New("symbol not found")
 // ErrNotELF is returned when the file is not an ELF
 var ErrNotELF = errors.New("not an ELF file")
 
+// ErrNoTbss is returned when the tbss section cannot be found
+var ErrNoTbss = errors.New("no thread-local uninitialized data section (tbss)")
+
+// ErrNoTdata is returned when the tdata section cannot be found
+var ErrNoTdata = errors.New("no thread-local initialized data section (tdata)")
+
 // File represents an open ELF file
 type File struct {
 	// closer is called internally when resources for this File are to be released
@@ -426,7 +432,20 @@ func (f *File) Tbss() (*Section, error) {
 			return &sec, nil
 		}
 	}
-	return nil, errors.New("no thread-local uninitialized data section (tbss)")
+	return nil, ErrNoTbss
+}
+
+// Tdata gets the thread-local initialized data section
+func (f *File) Tdata() (*Section, error) {
+	if err := f.LoadSections(); err != nil {
+		return nil, err
+	}
+	for _, sec := range f.Sections {
+		if sec.Type == elf.SHT_PROGBITS && sec.Flags&elf.SHF_TLS != 0 {
+			return &sec, nil
+		}
+	}
+	return nil, ErrNoTdata
 }
 
 // ReadVirtualMemory reads bytes from given virtual address


### PR DESCRIPTION
On x86, finding thread-local variables requires us to know the size of the per-thread TLS image. This is the .tdata section followed by the .tbss section.

Previously, we were only taking into account the .tbss section, which was not caught earlier because I only tested with programs where .tdata was empty on x86.