### PR TITLE
Soften kernel mod file parsing problems

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -122,10 +122,15 @@ func GetKernelModules(modulesPath string,
 
 		count++
 
-		nFields, _ := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
+		nFields, err := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
 			&name, &size, &refcount, &dependencies, &state, &address)
+		if err != nil {
+			log.Warnf("err parsing line in modules: '%s'", err)
+			continue
+		}
 		if nFields < 6 {
-			return nil, fmt.Errorf("unexpected line in modules: '%s'", line)
+			log.Warnf("unexpected line in modules: '%s'", line)
+			continue
 		}
 		if address == 0 {
 			continue


### PR DESCRIPTION
Turn errors like this into warnings:

level=error msg=\"Failed to load eBPF tracer: failed to read kernel modules: unexpected line in modules: 'iTCO_wdt 12288 - - Live 0xffffffffc044c000'\"\n"