### PR TITLE
mod parsing up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module go.opentelemetry.io/ebpf-profiler
 go 1.22.2
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.30.5
 	github.com/aws/aws-sdk-go-v2/config v1.27.35
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.62.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cilium/ebpf v0.16.0
-	github.com/elastic/go-freelru v0.15.0
+	github.com/elastic/go-freelru v0.16.0
 	github.com/elastic/go-perf v0.0.0-20241016160959-1342461adb4a
 	github.com/google/uuid v1.6.0
 	github.com/jsimonetti/rtnetlink v1.4.2
@@ -29,7 +29,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.30.5 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.33 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.33 h1:lBHAQQznENv0gLHAZ73ONiTSkCt
 github.com/aws/aws-sdk-go-v2/credentials v1.17.33/go.mod h1:MBuqCUOT3ChfLuxNDGyra67eskx7ge9e3YKYBce7wpI=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.13 h1:pfQ2sqNpMVK6xz2RbqLEL0GH87JOwSxPV2rzm8Zsb74=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.13/go.mod h1:NG7RXPUlqfsCLLFfi0+IpKN4sCB9D9fw/qTaSB+xRoU=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.21 h1:sV0doPPsRT7gMP0BnDPwSsysVTV/nKpB/nFmMnz8goE=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.21/go.mod h1:ictvfJWqE2gkUFDRJVp5VU/TrytuzK88DYcpan7UYuA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.17 h1:pI7Bzt0BJtYA0N/JEC6B8fJ4RBrEMi1LBrkMdFYNSnQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.17/go.mod h1:Dh5zzJYMtxfIjYW+/evjQ8uj2OyR/ve2KROHGHlSFqE=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.17 h1:Mqr/V5gvrhA2gvgnF42Zh5iMiQNcOYthFYwCyrnuWlc=
@@ -43,10 +41,8 @@ github.com/cilium/ebpf v0.16.0/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEn
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/elastic/go-freelru v0.13.0 h1:TKKY6yCfNNNky7Pj9xZAOEpBcdNgZJfihEftOb55omg=
-github.com/elastic/go-freelru v0.13.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
-github.com/elastic/go-freelru v0.15.0 h1:Jo1aY8JAvpyxbTDJEudrsBfjFDaALpfVv8mxuh9sfvI=
-github.com/elastic/go-freelru v0.15.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
+github.com/elastic/go-freelru v0.16.0 h1:gG2HJ1WXN2tNl5/p40JS/l59HjvjRhjyAa+oFTRArYs=
+github.com/elastic/go-freelru v0.16.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/elastic/go-perf v0.0.0-20241016160959-1342461adb4a h1:ymmtaN4bVCmKKeu4XEf6JEWNZKRXPMng1zjpKd+8rCU=
 github.com/elastic/go-perf v0.0.0-20241016160959-1342461adb4a/go.mod h1:Nt+pnRYvf0POC+7pXsrv8ubsEOSsaipJP0zlz1Ms1RM=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=

--- a/host/host.go
+++ b/host/host.go
@@ -55,4 +55,5 @@ type Trace struct {
 	TID              libpf.PID
 	APMTraceID       libpf.APMTraceID
 	APMTransactionID libpf.APMTransactionID
+	CPU              int
 }

--- a/libpf/cgroupv2.go
+++ b/libpf/cgroupv2.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package libpf // import "go.opentelemetry.io/ebpf-profiler/libpf"
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+
+	lru "github.com/elastic/go-freelru"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	cgroupv2PathPattern = regexp.MustCompile(`0:.*?:(.*)`)
+)
+
+// LookupCgroupv2 returns the cgroupv2 ID for pid.
+func LookupCgroupv2(cgrouplru *lru.SyncedLRU[PID, string], pid PID) (string, error) {
+	id, ok := cgrouplru.Get(pid)
+	if ok {
+		return id, nil
+	}
+
+	// Slow path
+	f, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var genericCgroupv2 string
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 512)
+	// Providing a predefined buffer overrides the internal buffer that Scanner uses (4096 bytes).
+	// We can do that and also set a maximum allocation size on the following call.
+	// With a maximum of 4096 characters path in the kernel, 8192 should be fine here. We don't
+	// expect lines in /proc/<PID>/cgroup to be longer than that.
+	scanner.Buffer(buf, 8192)
+	var pathParts []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		pathParts = cgroupv2PathPattern.FindStringSubmatch(line)
+		if pathParts == nil {
+			log.Debugf("Could not extract cgroupv2 path from line: %s", line)
+			continue
+		}
+		genericCgroupv2 = pathParts[1]
+		break
+	}
+
+	// Cache the cgroupv2 information.
+	// To avoid busy lookups, also empty cgroupv2 information is cached.
+	cgrouplru.Add(pid, genericCgroupv2)
+
+	return genericCgroupv2, nil
+}

--- a/libpf/libpf.go
+++ b/libpf/libpf.go
@@ -5,8 +5,6 @@ package libpf // import "go.opentelemetry.io/ebpf-profiler/libpf"
 
 import (
 	"encoding/json"
-	"fmt"
-	"math"
 	"time"
 )
 
@@ -32,35 +30,8 @@ func NowAsUInt32() uint32 {
 	return uint32(time.Now().Unix())
 }
 
-// UnixTime64 represents nanoseconds or (reduced precision) seconds since epoch.
+// UnixTime64 represents nanoseconds since epoch.
 type UnixTime64 uint64
-
-func (t UnixTime64) MarshalJSON() ([]byte, error) {
-	if t > math.MaxUint32 {
-		// Nanoseconds, ES does not support 'epoch_nanoseconds' so
-		// we have to pass it a value formatted as 'strict_date_optional_time_nanos'.
-		out := []byte(fmt.Sprintf("%q",
-			time.Unix(0, int64(t)).UTC().Format(time.RFC3339Nano)))
-		return out, nil
-	}
-
-	// Reduced precision seconds-since-the-epoch, ES 'epoch_second' formatter will match these.
-	out := []byte(fmt.Sprintf("%d", t))
-	return out, nil
-}
-
-// Unix returns the value as seconds since epoch.
-func (t UnixTime64) Unix() int64 {
-	if t > math.MaxUint32 {
-		// Nanoseconds, convert to seconds-since-the-epoch
-		return time.Unix(0, int64(t)).Unix()
-	}
-
-	return int64(t)
-}
-
-// Compile-time interface checks
-var _ json.Marshaler = (*UnixTime64)(nil)
 
 // AddressOrLineno represents a line number in an interpreted file or an offset into
 // a native file.

--- a/libpf/libpf_test.go
+++ b/libpf/libpf_test.go
@@ -4,12 +4,9 @@
 package libpf
 
 import (
-	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTraceType(t *testing.T) {
@@ -43,37 +40,5 @@ func TestTraceType(t *testing.T) {
 		assert.Equal(t, test.isErr, test.ty.IsError())
 		assert.Equal(t, test.interp, test.ty.Interpreter())
 		assert.Equal(t, test.str, test.ty.String())
-	}
-}
-
-func TestUnixTime64_MarshalJSON(t *testing.T) {
-	tests := []struct {
-		name string
-		time UnixTime64
-		want []byte
-	}{
-		{
-			name: "zero",
-			time: UnixTime64(0),
-			want: []byte(strconv.Itoa(0)),
-		},
-		{
-			name: "non-zero, seconds since the epoch",
-			time: UnixTime64(1710349106),
-			want: []byte(strconv.Itoa(1710349106)),
-		},
-		{
-			name: "non-zero, nanoseconds since the epoch",
-			time: UnixTime64(1710349106864964685),
-			want: []byte(fmt.Sprintf("%q", "2024-03-13T16:58:26.864964685Z")),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			b, err := test.time.MarshalJSON()
-			require.NoError(t, err)
-			assert.Equal(t, test.want, b)
-		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func mainWithExitCode() exitCode {
 		GRPCStartupBackoffTime:   intervals.GRPCStartupBackoffTime(),
 		GRPCConnectionTimeout:    intervals.GRPCConnectionTimeout(),
 		ReportInterval:           intervals.ReportInterval(),
-		ExecutablesCacheElements: 4096,
+		ExecutablesCacheElements: 16384,
 		// Next step: Calculate FramesCacheElements from numCores and samplingRate.
 		FramesCacheElements: 65536,
 		CGroupCacheElements: 1024,

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -121,10 +121,15 @@ func GetKernelModules(modulesPath string,
 
 		count++
 
-		nFields, _ := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
+		nFields, err := fmt.Sscanf(line, "%s %d %d %s %s 0x%x",
 			&name, &size, &refcount, &dependencies, &state, &address)
+		if err != nil {
+			log.Warnf("err parsing line in modules: '%s'", err)
+			continue
+		}
 		if nFields < 6 {
-			return nil, fmt.Errorf("unexpected line in modules: '%s'", line)
+			log.Warnf("unexpected line in modules: '%s'", line)
+			continue
 		}
 		if address == 0 {
 			continue

--- a/reporter/iface.go
+++ b/reporter/iface.go
@@ -36,6 +36,7 @@ type TraceEventMeta struct {
 	Comm           string
 	APMServiceName string
 	PID, TID       libpf.PID
+	CPU            int
 }
 
 type TraceReporter interface {

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -29,6 +29,10 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
 )
 
+const (
+	executableCacheLifetime = 1 * time.Hour
+)
+
 // Assert that we implement the full Reporter interface.
 var _ Reporter = (*OTLPReporter)(nil)
 
@@ -147,7 +151,7 @@ func NewOTLP(cfg *Config) (*OTLPReporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	executables.SetLifetime(1 * time.Hour) // Allow GC to clean stale items.
+	executables.SetLifetime(executableCacheLifetime) // Allow GC to clean stale items.
 
 	frames, err := lru.NewSynced[libpf.FileID,
 		*xsync.RWMutex[map[libpf.AddressOrLineno]sourceInfo]](
@@ -574,7 +578,9 @@ func (r *OTLPReporter) getProfile() (profile *profiles.Profile, startTS, endTS u
 					fileIDtoMapping[traceInfo.files[i]] = idx
 					locationMappingIndex = idx
 
-					execInfo, exists := r.executables.Get(traceInfo.files[i])
+					// Ensure that actively used executables do not expire.
+					execInfo, exists := r.executables.GetAndRefresh(traceInfo.files[i],
+						executableCacheLifetime)
 
 					// Next step: Select a proper default value,
 					// if the name of the executable is not known yet.

--- a/reporter/runloop.go
+++ b/reporter/runloop.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+// runLoop implements the run loop for all reporters
+type runLoop struct {
+	// stopSignal is the stop signal for shutting down all background tasks.
+	stopSignal chan libpf.Void
+}
+
+func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, run, purge func()) {
+	go func() {
+		tick := time.NewTicker(reportInterval)
+		defer tick.Stop()
+		purgeTick := time.NewTicker(5 * time.Minute)
+		defer purgeTick.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-rl.stopSignal:
+				return
+			case <-tick.C:
+				run()
+				tick.Reset(libpf.AddJitter(reportInterval, 0.2))
+			case <-purgeTick.C:
+				purge()
+			}
+		}
+	}()
+}
+
+func (rl *runLoop) Stop() {
+	close(rl.stopSignal)
+}

--- a/tracehandler/tracehandler.go
+++ b/tracehandler/tracehandler.go
@@ -126,6 +126,7 @@ func (m *traceHandler) HandleTrace(bpfTrace *host.Trace) {
 		PID:            bpfTrace.PID,
 		TID:            bpfTrace.TID,
 		APMServiceName: "", // filled in below
+		CPU:            bpfTrace.CPU,
 	}
 
 	if !m.reporter.SupportsReportTraceEvent() {

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -134,7 +134,7 @@ func startPerfEventMonitor(ctx context.Context, perfEventMap *ebpf.Map,
 // calls. Returns a function that can be called to retrieve perf event array
 // error counts.
 func startPollingPerfEventMonitor(ctx context.Context, perfEventMap *ebpf.Map,
-	pollFrequency time.Duration, perCPUBufferSize int, triggerFunc func([]byte),
+	pollFrequency time.Duration, perCPUBufferSize int, triggerFunc func([]byte, int),
 ) func() (lost, noData, readError uint64) {
 	eventReader, err := perf.NewReader(perfEventMap, perCPUBufferSize)
 	if err != nil {
@@ -178,7 +178,7 @@ func startPollingPerfEventMonitor(ctx context.Context, perfEventMap *ebpf.Map,
 					noDataCount.Add(1)
 					continue
 				}
-				triggerFunc(data.RawSample)
+				triggerFunc(data.RawSample, data.CPU)
 			}
 		}
 	}()


### PR DESCRIPTION
- **Extract reporter runloop (#228)**
- **Extract lookupcgroupv2 out of the otlp reporter (#227)**
- **Add CPU id to trace and trace metadata (#249)**
- **reporter: don't expire actively used executables (#247)**
- **Remove legacy code from libpf.UnixTime64 (#252)**
- **Turn kernel module file parsing errors into warnings**
