### PR TITLE
Fix varinfo parsing for luajit local var name lookup

### DIFF
--- a/interpreter/luajit/proto.go
+++ b/interpreter/luajit/proto.go
@@ -356,13 +356,15 @@ func parseVarinfo(b []byte, pc, slot uint32) string {
 		}
 		b, pcdelta = parseULEB128(b)
 		endpc := startpc + pcdelta
-		if pc < endpc && slot == 0 {
-			if vn <= len(varnames) {
-				return varnames[vn-1]
+		if pc < endpc {
+			if slot == 0 {
+				if vn <= len(varnames) {
+					return varnames[vn-1]
+				}
+				return name
 			}
-			return name
+			slot--
 		}
-		slot--
 	}
 	return ""
 }

--- a/interpreter/luajit/proto_test.go
+++ b/interpreter/luajit/proto_test.go
@@ -12,59 +12,49 @@
 package luajit
 
 import (
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// literal go
-// add commas between each element
-//
-//nolint:lll
-const bytes = "105 110 112 117 116 0 0 99 108 101 110 0 14 85 100 105 99 116 0 8 77 97 0 2 75 98 0 0 75 114 101 115 117 108 116 0 1 74 114 101 115 117 108 116 108 101 110 0 1 73 110 0 1 72 119 111 114 100 0 1 71 1 3 49 2 0 49 3 0 49 105 0 1 47 99 0 5 42 119 99 0 3 39 119 114 105 116 101 0 12 25 0"
-
 func TestParseVarinfo(t *testing.T) {
-	strs := strings.Split(bytes, " ")
-	b := make([]byte, len(strs))
-	for i, s := range strs {
-		num, err := strconv.ParseInt(s, 10, 8)
-		require.NoError(t, err)
-		b[i] = byte(num)
+	// Lifted from bcline function in bc.lua:
+	// https://github.com/openresty/luajit2/blob/098183d/src/jit/bc.lua#L65
+	b := []byte{0x66, 0x75, 0x6e, 0x63, 0x0, 0x0, 0xdc, 0x1, 0x70, 0x63, 0x0, 0x0, 0xdc, 0x1, 0x70,
+		0x72, 0x65, 0x66, 0x69, 0x78, 0x0, 0x0, 0xdc, 0x1, 0x6c, 0x69, 0x6e, 0x65, 0x69, 0x6e,
+		0x66, 0x6f, 0x0, 0x0, 0xdc, 0x1, 0x69, 0x6e, 0x73, 0x0, 0xa, 0xd2, 0x1, 0x6d, 0x0, 0x0,
+		0xd2, 0x1, 0x6c, 0x0, 0x0, 0xd2, 0x1, 0x6d, 0x61, 0x0, 0xf, 0xc3, 0x1, 0x6d, 0x62, 0x0,
+		0x0, 0xc3, 0x1, 0x6d, 0x63, 0x0, 0x0, 0xc3, 0x1, 0x61, 0x0, 0x7, 0xbc, 0x1, 0x6f, 0x69,
+		0x64, 0x78, 0x0, 0x5, 0xb7, 0x1, 0x6f, 0x70, 0x0, 0x5, 0xb2, 0x1, 0x73, 0x0, 0x1, 0xb1,
+		0x1, 0x64, 0x0, 0x27, 0x8a, 0x1, 0x6b, 0x63, 0x0, 0x17, 0x73, 0x66, 0x69, 0x0, 0x2c, 0x9,
+		0x6b, 0x61, 0x0, 0x17, 0x8, 0x62, 0x0, 0xe, 0xf, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x79,
+		0xf5, 0x0}
+	for _, tc := range []struct {
+		name          string
+		startpc, endp uint32
+		slot          uint32
+	}{
+		{"func", 0, 220, 0},
+		{"pc", 0, 220, 1},
+		{"prefix", 0, 220, 2},
+		{"lineinfo", 0, 220, 3},
+		{"ins", 10, 220, 4},
+		{"m", 10, 220, 5},
+		{"l", 10, 220, 6},
+		{"ma", 25, 220, 7},
+		{"mb", 25, 220, 8},
+		{"mc", 25, 220, 9},
+		{"a", 32, 220, 10},
+		{"oidx", 37, 220, 11},
+		{"op", 42, 220, 12},
+		{"s", 43, 220, 13},
+		{"d", 82, 220, 14},
+		{"kc", 105, 220, 15},
+		{"fi", 149, 158, 16},
+		{"ka", 172, 180, 16},
+		{"b", 186, 201, 16},
+	} {
+		s := parseVarinfo(b, tc.startpc, tc.slot)
+		require.Equal(t, s, tc.name)
 	}
-	str := parseVarinfo(b, 2, 0)
-	t.Log(str)
-	str = parseVarinfo(b, 14, 1)
-	t.Log(str)
-	str = parseVarinfo(b, 23, 2)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 3)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 4)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 5)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 6)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 7)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 8)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 9)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 10)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 11)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 12)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 13)
-	t.Log(str)
-	str = parseVarinfo(b, 40, 14)
-	t.Log(str)
-	str = parseVarinfo(b, 60, 15)
-	t.Log(str)
-	str = parseVarinfo(b, 60, 16)
-	t.Log(str)
 }


### PR DESCRIPTION
We were decrementing the slot when PC was out of bounds which is wrong
because LuaJIT reuses stack slots for locals in different scopes. This
caused us to hit on local var lookup instead of failing and falling
through to looking at bytecode names.

Add a test case lifted from luajit that shows slots being reused for
different variables and remove old unhelpful test case.
