### PR TITLE
Fix kernel module parsing when flags are present

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -165,8 +165,10 @@ type kernelModule struct {
 }
 
 func parseKernelModuleLine(line string) (kernelModule, error) {
-	// The format is: "name size refcount dependencies state address"
-	parts := strings.SplitN(line, " ", 6)
+	// The format is: "name size refcount dependencies state address flags"
+	parts := strings.SplitN(line, " ", 7)
+
+	// At least 6 parts are expected (flags are not always present and are not needed here)
 	if len(parts) < 6 {
 		return kernelModule{}, fmt.Errorf("unexpected line in modules: '%s'", line)
 	}

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -48,12 +48,13 @@ ahci 45056 - - Live 0xffffffffc0294000
 libahci 49152 - - Live 0xffffffffc027f000
 sp5100_tco 12288 - - Live 0xffffffffc0274000
 watchdog 40960 - - Live 0xffffffffc025f000
-k10temp 12288 - - Live 0xffffffffc0254000`)
+k10temp 12288 - - Live 0xffffffffc0254000
+vboxguest 499712 - - Live 0xffffffffc097d000 (OE)`)
 
 	kmods, err := parseKernelModules(bufio.NewScanner(bytes.NewReader(content)))
 	require.NoError(t, err)
 
-	require.Len(t, kmods, 7)
+	require.Len(t, kmods, 8)
 	require.Equal(t, []kernelModule{
 		{
 			name:    "i40e",
@@ -89,6 +90,11 @@ k10temp 12288 - - Live 0xffffffffc0254000`)
 			name:    "k10temp",
 			size:    12288,
 			address: 0xffffffffc0254000,
+		},
+		{
+			name:    "vboxguest",
+			size:    499712,
+			address: 0xffffffffc097d000,
 		},
 	}, kmods)
 }


### PR DESCRIPTION
Fixes issue mentioned at https://github.com/parca-dev/parca-agent/issues/3018 and https://github.com/parca-dev/opentelemetry-ebpf-profiler/issues/29

If a line `/proc/modules` has flags they are now ignored instead of included as part of the address. This is done by splitting the line by 7 at most instead of 6 at most.