### PR TITLE
Check for luajit presence by symbols

### DIFF
--- a/interpreter/luajit/luajit.go
+++ b/interpreter/luajit/luajit.go
@@ -131,7 +131,7 @@ func (l *luajitInstance) Detach(ebpf interpreter.EbpfHandler, pid libpf.PID) err
 
 func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpreter.Data, error) {
 	base := path.Base(info.FileName())
-	if !strings.HasPrefix(base, "libluajit-5.1.so") && base != "luajit" {
+	if !strings.HasPrefix(base, "libluajit-5.1.so") && base != "luajit" && base != "nginx" && base != "openresty" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
We use heavily modified openresty nginx, where we statically link the luajit into the nginx binary. Hence, I propose we check for luajit _presence_ by symbols, namely the `lua_newstate`, which should be used by everyone who is integrating the luajit into their application.