### PR TITLE
Go version detection tweaks

### DIFF
--- a/interpreter/golang/golang.go
+++ b/interpreter/golang/golang.go
@@ -70,7 +70,7 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 		// are our best bet.
 		log.Warnf("version %s unknown; using offsets for latest known Go version %s."+
 			"If Go traceID integration and other custom labels support is buggy,"+
-			" try upgrading to the latest version.", goVersion, latestVersion)
+			" try upgrading to the latest profiler version.", goVersion, latestVersion)
 		return data{
 			goVersion: goVersion,
 			offsets:   allOffsets[latestVersion],

--- a/interpreter/golang/golang.go
+++ b/interpreter/golang/golang.go
@@ -66,17 +66,14 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 
 	offsets, ok := allOffsets[majorMinor]
 	if !ok {
-		// Info instead of warn: this is often going to be fine,
-		// as the offsets tend not to change every release cycle.
-		//
-		// TODO: Reword the message if we upstream this,
-		// since it mentions `parca-agent` by name.
-		log.Infof("version %s unknown; using offsets for latest known Go version %s."+
+		// If we don't know this version its probably a new version and the latest offsets
+		// are our best bet.
+		log.Warnf("version %s unknown; using offsets for latest known Go version %s."+
 			"If Go traceID integration and other custom labels support is buggy,"+
-			" try upgrading parca-agent to the latest version.", goVersion, defaultVersion)
+			" try upgrading to the latest version.", goVersion, latestVersion)
 		return data{
 			goVersion: goVersion,
-			offsets:   allOffsets[defaultVersion],
+			offsets:   allOffsets[latestVersion],
 		}, nil
 	}
 

--- a/interpreter/golang/runtime_data.go
+++ b/interpreter/golang/runtime_data.go
@@ -8,6 +8,11 @@ import "C"
 // Consider bumping this whenever a new version of Go is released.
 var latestVersion = "go1.24"
 
+// Offsets come from DWARF debug information:
+// https://github.com/parca-dev/parca-agent/blob/2815ded21704934c/pkg/runtime/golang/golang.go#L85
+// However since DWARF information can be stripped we record them here.
+// TODO: Should we look for DWARF information to support new versions
+// automatically when available?
 var allOffsets = map[string]C.GoCustomLabelsOffsets{
 	"go1.13": {
 		m_offset:               48,

--- a/interpreter/golang/runtime_data.go
+++ b/interpreter/golang/runtime_data.go
@@ -6,25 +6,9 @@ import "C"
 
 // defaultVersion is used if the go binary has an unrecognized major+minor version.
 // Consider bumping this whenever a new version of Go is released.
-var defaultVersion = "go1.23"
+var latestVersion = "go1.24"
 
 var allOffsets = map[string]C.GoCustomLabelsOffsets{
-	"go1.11": {
-		m_offset:               48,
-		curg:                   192,
-		labels:                 344,
-		hmap_count:             0,
-		hmap_log2_bucket_count: 9,
-		hmap_buckets:           16,
-	},
-	"go1.12": {
-		m_offset:               48,
-		curg:                   192,
-		labels:                 344,
-		hmap_count:             0,
-		hmap_log2_bucket_count: 9,
-		hmap_buckets:           16,
-	},
 	"go1.13": {
 		m_offset:               48,
 		curg:                   192,


### PR DESCRIPTION
To avoid excessive memory usage don't recognize go binaries unless
the .go.buildinfo section is present.
