### PR TITLE
Expose custom labels max key/value lengths

### DIFF
--- a/support/types.go
+++ b/support/types.go
@@ -130,3 +130,8 @@ const (
 	sizeof_PHPProcInfo    = 0x18
 	sizeof_RubyProcInfo   = 0x20
 )
+
+const (
+	CustomLabelMaxKeyLen = 0x10
+	CustomLabelMaxValLen = 0x30
+)

--- a/support/types_def.go
+++ b/support/types_def.go
@@ -108,3 +108,8 @@ const (
 	sizeof_PHPProcInfo    = C.sizeof_PHPProcInfo
 	sizeof_RubyProcInfo   = C.sizeof_RubyProcInfo
 )
+
+const (
+	CustomLabelMaxKeyLen	= C.CUSTOM_LABEL_MAX_KEY_LEN
+	CustomLabelMaxValLen	= C.CUSTOM_LABEL_MAX_VAL_LEN
+)


### PR DESCRIPTION
This will let us (in `parca-agent` code) detect when a value has been truncated and react appropriately.