### PR TITLE
LuaJIT improved diagnostics and rsi/esi fix

### DIFF
--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -510,6 +510,8 @@ func sameReg(r1, r2 x86asm.Reg) bool {
 			return r2 == x86asm.RDX
 		case x86asm.EBX:
 			return r2 == x86asm.RBX
+		case x86asm.ESI:
+			return r2 == x86asm.RSI
 		default:
 			return false
 		}

--- a/interpreter/luajit/offsets_test.go
+++ b/interpreter/luajit/offsets_test.go
@@ -165,15 +165,20 @@ func getLibFromImage(t *testing.T, name, platform, fullPath, target string) {
 }
 
 // spot testing
-func TestFile(t *testing.T) {
-	for _, target := range []string{
-		"./testdata/libluajit-5.1-jammy.so",
-		"./testdata/luajit-nixos"} {
-		if _, err := os.Stat(target); os.IsNotExist(err) {
+func TestFiles(t *testing.T) {
+	files, err := os.ReadDir("./testdata")
+	require.NoError(t, err)
+	for _, de := range files {
+		target := "./testdata/" + de.Name()
+		fi, err := os.Stat(target)
+		if err != nil || fi.IsDir() {
 			continue
 		}
 		ef, err := pfelf.Open(target)
-		require.NoError(t, err)
+		// Skip non-elf files
+		if err != nil {
+			continue
+		}
 		ljd := luajitData{}
 
 		// create stacktrace deltas to make sure we can find interp bounds
@@ -208,7 +213,7 @@ func TestFile(t *testing.T) {
 			require.Equal(t, uint64(du.Address), du2)
 		}
 
-		t.Logf("%+v, interp: %+v", ljd, interp)
+		t.Logf("%s: %+v, interp: %+v", target, ljd, interp)
 	}
 }
 

--- a/interpreter/luajit/trace.go
+++ b/interpreter/luajit/trace.go
@@ -93,6 +93,7 @@ func loadTraces(tracesAddr libpf.Address, rm remotememory.RemoteMemory) (uint64,
 		if t.traceno > uint16(sztrace) {
 			return 0, nil, errors.New("invalid traceno")
 		}
+		logf("lj: added trace(%d) from %x", t.traceno, tracesAddr)
 		traces[t.traceno] = t
 	}
 	return h, traces, nil

--- a/support/types_def.go
+++ b/support/types_def.go
@@ -110,6 +110,6 @@ const (
 )
 
 const (
-	CustomLabelMaxKeyLen	= C.CUSTOM_LABEL_MAX_KEY_LEN
-	CustomLabelMaxValLen	= C.CUSTOM_LABEL_MAX_VAL_LEN
+	CustomLabelMaxKeyLen = C.CUSTOM_LABEL_MAX_KEY_LEN
+	CustomLabelMaxValLen = C.CUSTOM_LABEL_MAX_VAL_LEN
 )


### PR DESCRIPTION
Add some more logging to luajit and have the processVMs algorithm not stop completely if it sees an error, instead log it and try additional traces and other vm instances.