### PR TITLE
Fix merge

### DIFF
--- a/tracer/systemconfig.go
+++ b/tracer/systemconfig.go
@@ -248,7 +248,7 @@ func loadSystemConfig(coll *cebpf.CollectionSpec, maps map[string]*cebpf.Map,
 		}
 
 		if includeTracers.Has(types.PerlTracer) || includeTracers.Has(types.PythonTracer) ||
-			includeTracers.Has(types.GoLabels) || includeTracers.Has(types.Labels) {
+			includeTracers.Has(types.Labels) {
 			var tpbaseOffset uint64
 			tpbaseOffset, err = loadTPBaseOffset(coll, maps, kmod)
 			if err != nil {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -384,7 +384,7 @@ func initializeMapsAndPrograms(kmod *kallsyms.Module, cfg *Config) (
 		{
 			progID: uint32(support.ProgGoLabels),
 			name:   "go_labels",
-			enable: cfg.IncludeTracers.Has(types.GoLabels) || cfg.IncludeTracers.Has(types.Labels),
+			enable: cfg.IncludeTracers.Has(types.Labels),
 		},
 		{
 			progID: uint32(support.ProgUnwindLuaJIT),

--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -22,7 +22,6 @@ const (
 	RubyTracer
 	V8Tracer
 	DotnetTracer
-	GoLabels
 	LuaJITTracer
 	GoTracer
 	Labels
@@ -39,7 +38,6 @@ var tracerTypeToName = map[tracerType]string{
 	RubyTracer:    "ruby",
 	V8Tracer:      "v8",
 	DotnetTracer:  "dotnet",
-	GoLabels:      "go-labels",
 	LuaJITTracer:  "luajit",
 	GoTracer:      "go",
 	Labels:        "labels",


### PR DESCRIPTION
"labels" controls the go-labels tracer and go-labels was removed to avoid confusion with "go" tracer and to allow non-go labels in the future.