### PR TITLE
Retract some upstream tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,3 +123,9 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v0.0.202531
+	v0.0.202529
+	v0.0.202527
+)


### PR DESCRIPTION
It seems likely that these tags were added by mistake. They interfere with the upgrade script in parca-agent using the `@latest` version query to get the latest code in the parca-dev fork.