### PR TITLE
Improvements to AttachUSDTProbe

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -232,3 +232,33 @@ jobs:
         run: |
           uname -a
           sudo go test ./interpreter/... -v -run TestIntegration
+
+  rtld-qemu-tests:
+    name: RTLD QEMU tests (kernel ${{ matrix.kernel }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        kernel:
+          - 5.10.217  # Pre-6.6, uses single-shot mode
+          - 6.8.10    # Post-6.6, supports multi-uprobe
+    steps:
+      - name: Clone code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y qemu-system-x86 debootstrap
+      - name: Download kernel
+        run: |
+          cd test/rtld-qemu
+          ./download-kernel.sh ${{ matrix.kernel }}
+      - name: Run RTLD tests in QEMU
+        run: |
+          cd test/rtld-qemu
+          ./build-and-run.sh ${{ matrix.kernel }}

--- a/interpreter/instancestubs.go
+++ b/interpreter/instancestubs.go
@@ -4,12 +4,17 @@
 package interpreter // import "go.opentelemetry.io/ebpf-profiler/interpreter"
 
 import (
+	"unsafe"
+
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/process"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/tpbase"
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 // InstanceStubs provides empty implementations of Instance hooks that are
@@ -36,4 +41,45 @@ func (is *InstanceStubs) GetAndResetMetrics() ([]metrics.Metric, error) {
 
 func (is *InstanceStubs) Symbolize(*host.Frame, *libpf.Frames) error {
 	return ErrMismatchInterpreterType
+}
+
+type EbpfHandlerStubs struct{}
+
+func (m *EbpfHandlerStubs) UpdatePidInterpreterMapping(_ libpf.PID,
+	pfx lpm.Prefix, _ uint8, _ host.FileID, _ uint64) error {
+	return nil
+}
+
+func (m *EbpfHandlerStubs) DeletePidInterpreterMapping(_ libpf.PID, _ lpm.Prefix) error {
+	return nil
+}
+
+func (m *EbpfHandlerStubs) CoredumpTest() bool {
+	return false
+}
+
+func (m *EbpfHandlerStubs) UpdateInterpreterOffsets(uint16, host.FileID,
+	[]util.Range) error {
+	return nil
+}
+
+func (m *EbpfHandlerStubs) UpdateProcData(libpf.InterpreterType, libpf.PID,
+	unsafe.Pointer) error {
+	return nil
+}
+
+func (m *EbpfHandlerStubs) DeleteProcData(libpf.InterpreterType, libpf.PID) error {
+	return nil
+}
+
+func (mockup *EbpfHandlerStubs) AttachUSDTProbes(libpf.PID, string, string, []pfelf.USDTProbe,
+	[]uint64, []string, bool) (LinkCloser, error) {
+	return nil, nil
+}
+
+func (mockup *EbpfHandlerStubs) TriggerProcessSync(libpf.PID) error {
+	return nil
+}
+
+func (mockup *EbpfHandlerStubs) SetProcessSyncTrigger(func(pid libpf.PID)) {
 }

--- a/interpreter/luajit/mappings_test.go
+++ b/interpreter/luajit/mappings_test.go
@@ -13,17 +13,13 @@ package luajit
 import (
 	"debug/elf"
 	"testing"
-	"unsafe"
 
-	"github.com/cilium/ebpf/link"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/process"
-	"go.opentelemetry.io/ebpf-profiler/util"
 )
 
 type prefixKey struct {
@@ -33,14 +29,11 @@ type prefixKey struct {
 
 // ebpfMapsMockup implements the ebpf interface as test mockup
 type ebpfMapsMockup struct {
+	interpreter.EbpfHandlerStubs
 	prefixes map[prefixKey]lpm.Prefix
 }
 
 var _ interpreter.EbpfHandler = &ebpfMapsMockup{}
-
-func (m *ebpfMapsMockup) CoredumpTest() bool {
-	return false
-}
 
 func (m *ebpfMapsMockup) UpdatePidInterpreterMapping(pid libpf.PID,
 	pfx lpm.Prefix, _ uint8, _ host.FileID, _ uint64) error {
@@ -51,25 +44,6 @@ func (m *ebpfMapsMockup) UpdatePidInterpreterMapping(pid libpf.PID,
 func (m *ebpfMapsMockup) DeletePidInterpreterMapping(pid libpf.PID, pfx lpm.Prefix) error {
 	delete(m.prefixes, prefixKey{pid: pid, pfx: pfx})
 	return nil
-}
-
-func (m *ebpfMapsMockup) UpdateInterpreterOffsets(uint16, host.FileID,
-	[]util.Range) error {
-	return nil
-}
-
-func (m *ebpfMapsMockup) UpdateProcData(libpf.InterpreterType, libpf.PID,
-	unsafe.Pointer) error {
-	return nil
-}
-
-func (m *ebpfMapsMockup) DeleteProcData(libpf.InterpreterType, libpf.PID) error {
-	return nil
-}
-
-func (mockup *ebpfMapsMockup) AttachUSDTProbe(_ libpf.PID, _ string, _ pfelf.USDTProbe,
-	_ string) (link.Link, error) {
-	return nil, nil
 }
 
 // TestSynchronizeMappings tests that if a mapping is realloc'd we do the right thing.

--- a/interpreter/rtld/rtld.go
+++ b/interpreter/rtld/rtld.go
@@ -5,9 +5,9 @@ package rtld // import "go.opentelemetry.io/ebpf-profiler/interpreter/rtld"
 
 import (
 	"fmt"
-	"strings"
+	"path"
+	"regexp"
 
-	"github.com/cilium/ebpf/link"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -15,24 +15,34 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
+// LdsoRegexp matches ld.so filenames across different distributions
+var LdsoRegexp = regexp.MustCompile(
+	`^ld(?:-linux)?(?:-x86-64|-aarch64)?\.so\.\d+$|` +
+		`^ld\.so\.\d+$|` +
+		`^ld-\d+\.\d+\.so$|` +
+		`^ld-musl-[^/]+\.so\.\d+$`)
+
 // data holds the Uprobe link to keep it in memory
 type data struct {
-	probe     pfelf.USDTProbe
 	path      string
-	probeLink link.Link
+	usePoller bool
+	probe     pfelf.USDTProbe
+	lc        interpreter.LinkCloser
 }
 
 // instance represents a per-PID instance of the rtld interpreter
 type instance struct {
 	interpreter.InstanceStubs
-	link link.Link
+	usePoller bool
+	lc        interpreter.LinkCloser
 }
 
 // Loader detects if the ELF file contains the rtld:map_complete USDT probe
-func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpreter.Data, error) {
-	// Check if this is ld.so by examining the filename
+func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpreter.Data, error) {
+	// Check if this is ld.so by examining just the basename
 	fileName := info.FileName()
-	if !strings.Contains(fileName, "ld-") && !strings.Contains(fileName, "ld.so") {
+	baseName := path.Base(fileName)
+	if !LdsoRegexp.MatchString(baseName) {
 		return nil, nil
 	}
 
@@ -44,8 +54,11 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 	// Look for .note.stapsdt section which contains USDT probes
 	sec := ef.Section(".note.stapsdt")
 	if sec == nil {
-		log.Debugf("No .note.stapsdt section found in %s", fileName)
-		return nil, nil
+		log.Debugf("No .note.stapsdt section found in %s, will use poller fallback", fileName)
+		return &data{
+			path:      fileName,
+			usePoller: true,
+		}, nil
 	}
 
 	// Parse USDT probes from the section
@@ -53,46 +66,75 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse USDT probes: %w", err)
 	}
-
 	// Look for rtld:map_complete probe
 	for _, probe := range probes {
-		if probe.Provider == "rtld" && probe.Name == "map_complete" {
-			log.Infof("Found rtld:map_complete USDT probe in %s at 0x%x",
-				fileName, probe.Location)
-			return &data{
-				path:  fileName,
-				probe: probe,
-			}, nil
+		if probe.Provider != "rtld" || probe.Name != "map_complete" {
+			continue
 		}
+		log.Debugf("Found rtld:map_complete USDT probe in %s at 0x%x",
+			fileName, probe.Location)
+
+		return &data{
+			probe: probe,
+			path:  fileName,
+		}, nil
 	}
 
-	return nil, nil
+	// No rtld:map_complete probe found, use poller fallback
+	log.Debugf("No rtld:map_complete probe found in %s, will use poller fallback", fileName)
+	return &data{
+		path:      fileName,
+		usePoller: true,
+	}, nil
 }
 
-// Attach attaches the uprobe to the rtld:map_complete USDT probe
+// Attach attaches the uprobe to the rtld:map_complete USDT probe or registers with poller
 func (d *data) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, _ libpf.Address,
 	_ remotememory.RemoteMemory) (interpreter.Instance, error) {
-	link, err := ebpf.AttachUSDTProbe(pid, d.path, d.probe, "usdt_rtld_map_complete")
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach uprobe to rtld:map_complete usdt: %w", err)
+	if d.usePoller {
+		// Register this PID with the global poller
+		// Create a trigger function that calls TriggerProcessSync on the ebpf handler
+		triggerFunc := func(triggerPID libpf.PID) {
+			if err := ebpf.TriggerProcessSync(triggerPID); err != nil {
+				log.Debugf("[rtld] TriggerProcessSync failed for PID %d: %v", triggerPID, err)
+			}
+		}
+		getPoller(triggerFunc).registerPID(pid)
+		log.Debugf("[rtld] Registered PID %d with poller for %s", pid, d.path)
+
+		return &instance{usePoller: true}, nil
+	} else {
+		prog := "usdt_rtld_map_complete"
+		lc, err := ebpf.AttachUSDTProbes(
+			pid, d.path, prog, []pfelf.USDTProbe{d.probe}, nil, nil, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to attach uprobe to rtld:map_complete usdt: %w", err)
+		}
+		log.Debugf("[rtld] Using USDT probe for PID %d on %s", pid, d.path)
+		d.lc = lc
+		return &instance{lc: lc}, nil
 	}
-	log.Infof("Attached uprobe to rtld:map_complete usdt in PID %d", pid)
-	return &instance{link: link}, nil
 }
 
-// Detach removes the uprobe
+// Detach removes the uprobe or deregisters from poller
 func (i *instance) Detach(_ interpreter.EbpfHandler, pid libpf.PID) error {
 	log.Debugf("[rtld] Detach called for PID %d", pid)
+	if i.usePoller {
+		// Deregister this PID from the global poller
+		// Pass a nil trigger function since we're just deregistering
+		getPoller(nil).deregisterPID(pid)
+		log.Debugf("[rtld] Deregistered PID %d from poller", pid)
+	}
 	return nil
 }
 
 // Unload cleans up the uprobe link
 func (d *data) Unload(_ interpreter.EbpfHandler) {
-	if d.probeLink != nil {
-		if err := d.probeLink.Close(); err != nil {
-			log.Errorf("[rtld] Failed to close uprobe link: %v", err)
+	if d.lc != nil {
+		if err := d.lc.Unload(); err != nil {
+			log.Errorf("[rtld] Failed to unload uprobe link: %v", err)
 		}
-		d.probeLink = nil
+		d.lc = nil
 	}
 	log.Debugf("[rtld] Unloaded uprobe for %s", d.path)
 }

--- a/interpreter/rtld/rtld_poller.go
+++ b/interpreter/rtld/rtld_poller.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rtld // import "go.opentelemetry.io/ebpf-profiler/interpreter/rtld"
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"slices"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+var (
+	pollerInstance *mapsPoller
+	pollerOnce     sync.Once
+)
+
+type pidInfo struct {
+	hash string
+}
+
+type mapsPoller struct {
+	mu          sync.RWMutex
+	pids        map[libpf.PID]*pidInfo
+	quit        chan struct{}
+	stopped     bool
+	triggerFunc func(pid libpf.PID)
+	buffer      []byte         // Reusable buffer to avoid allocations
+	testNotify  chan libpf.PID // Channel for test notifications
+}
+
+func getPoller(triggerFunc func(pid libpf.PID)) *mapsPoller {
+	pollerOnce.Do(func() {
+		pollerInstance = &mapsPoller{
+			pids:        make(map[libpf.PID]*pidInfo),
+			quit:        make(chan struct{}),
+			buffer:      make([]byte, 64*1024), // 64KB buffer, reused across calls
+			triggerFunc: triggerFunc,
+		}
+		go pollerInstance.run()
+	})
+	return pollerInstance
+}
+
+func (p *mapsPoller) registerPID(pid libpf.PID) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stopped {
+		return
+	}
+
+	p.pids[pid] = &pidInfo{}
+	log.Debugf("[rtld] Registered PID %d for maps polling", pid)
+}
+
+func (p *mapsPoller) deregisterPID(pid libpf.PID) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	delete(p.pids, pid)
+	log.Debugf("[rtld] Deregistered PID %d from maps polling", pid)
+
+	// If no more PIDs, we could optionally stop the poller
+	// but keeping it running is fine for simplicity
+}
+
+func (p *mapsPoller) run() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	log.Debug("[rtld] Maps poller started")
+
+	for {
+		select {
+		case <-ticker.C:
+			p.checkMaps()
+		case <-p.quit:
+			log.Debug("[rtld] Maps poller stopped")
+			return
+		}
+	}
+}
+
+func (p *mapsPoller) checkMaps() {
+	p.mu.RLock()
+	// Make a copy of the PIDs to avoid holding the lock during file I/O
+	pids := make([]libpf.PID, 0, len(p.pids))
+	pids = slices.AppendSeq(pids, maps.Keys(p.pids))
+	p.mu.RUnlock()
+
+	for _, pid := range pids {
+		p.checkPIDMaps(pid)
+	}
+}
+
+func (p *mapsPoller) checkPIDMaps(pid libpf.PID) {
+	mapsPath := fmt.Sprintf("/proc/%d/maps", pid)
+
+	file, err := os.Open(mapsPath)
+	if err != nil {
+		// Process might have exited, remove it from our tracking
+		p.deregisterPID(pid)
+		return
+	}
+	defer file.Close()
+
+	// Calculate hash of entire maps file content using raw I/O
+	hasher := sha256.New()
+
+	// Use the shared buffer, no allocations in the hot path
+	for {
+		n, err := file.Read(p.buffer)
+		if n > 0 {
+			hasher.Write(p.buffer[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Debugf("[rtld] Error reading maps for PID %d: %v", pid, err)
+			return
+		}
+	}
+
+	newHash := hex.EncodeToString(hasher.Sum(nil))
+
+	p.mu.RLock()
+	info, exists := p.pids[pid]
+	p.mu.RUnlock()
+
+	if !exists {
+		// PID was deregistered while we were processing
+		return
+	}
+
+	if info.hash != newHash {
+		log.Debugf("[rtld] Maps changed for PID %d, triggering process sync", pid)
+		p.mu.Lock()
+		info.hash = newHash
+		p.mu.Unlock()
+
+		// Notify test if channel is available (non-blocking)
+		if p.testNotify != nil {
+			select {
+			case p.testNotify <- pid:
+			default:
+			}
+		}
+
+		if p.triggerFunc != nil {
+			p.triggerFunc(pid)
+		}
+	}
+}
+
+// Test helpers - exported functions for testing
+func GetPollerForTesting(triggerFunc func(pid libpf.PID)) interface{} {
+	return getPoller(triggerFunc)
+}
+
+func RegisterPIDForTesting(pid libpf.PID, triggerFunc func(pid libpf.PID)) {
+	getPoller(triggerFunc).registerPID(pid)
+}
+
+func DeregisterPIDForTesting(pid libpf.PID, triggerFunc func(pid libpf.PID)) {
+	getPoller(triggerFunc).deregisterPID(pid)
+}
+
+func SetTestNotifyChannelForTesting(ch chan libpf.PID, triggerFunc func(pid libpf.PID)) {
+	p := getPoller(triggerFunc)
+	p.mu.Lock()
+	p.testNotify = ch
+	p.mu.Unlock()
+}

--- a/interpreter/rtld/rtld_test.go
+++ b/interpreter/rtld/rtld_test.go
@@ -7,18 +7,59 @@ package rtld_test
 
 import (
 	"context"
+	"os"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
 
 	"github.com/coreos/pkg/dlopen"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/interpreter/rtld"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/support"
 	"go.opentelemetry.io/ebpf-profiler/testutils"
 	"go.opentelemetry.io/ebpf-profiler/tracer"
 	tracertypes "go.opentelemetry.io/ebpf-profiler/tracer/types"
+	"go.opentelemetry.io/ebpf-profiler/util"
 )
+
+func TestLdsoRegexp(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected bool
+	}{
+		// Standard glibc filenames
+		{"ld-linux-x86-64.so.2", true},
+		{"ld-linux-aarch64.so.1", true},
+		{"ld-2.31.so", true},
+		{"ld-2.35.so", true},
+
+		// Alternative ld.so naming
+		{"ld.so.1", true},
+		{"ld.so.2", true},
+		{"ld-linux.so.2", true},
+
+		// musl libc
+		{"ld-musl-x86_64.so.1", true},
+		{"ld-musl-aarch64.so.1", true},
+
+		// Invalid filenames
+		{"libc.so.6", false},
+		{"ld", false},
+		{"ld-linux.so", false},       // missing version number
+		{"ld-linux-x86-64.so", false}, // missing version number
+		{"libm.so.6", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := rtld.LdsoRegexp.MatchString(tc.name)
+			require.Equal(t, tc.expected, result, "Filename: %s", tc.name)
+		})
+	}
+}
 
 func TestIntegration(t *testing.T) {
 	if !testutils.IsRoot() {
@@ -67,6 +108,127 @@ func TestIntegration(t *testing.T) {
 		// Get the metrics after dlopen
 		finalCount := getEBPFMetricValue(trc, metrics.IDRtldMapCompleteHits)
 		t.Logf("Final rtld:map_complete metric count: %d", finalCount)
+
+		// Check that the metric was incremented
+		return finalCount > initialCount
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
+func TestIntegrationPoller(t *testing.T) {
+	// Get current process PID
+	pid := libpf.PID(os.Getpid())
+
+	// Create a notification channel for the test
+	notifyCh := make(chan libpf.PID, 10)
+	// Create a test trigger function
+	triggerFunc := func(triggerPID libpf.PID) {
+		t.Logf("Test trigger function called for PID %d", triggerPID)
+	}
+	rtld.SetTestNotifyChannelForTesting(notifyCh, triggerFunc)
+
+	// Register our PID with the poller
+	rtld.RegisterPIDForTesting(pid, triggerFunc)
+	defer rtld.DeregisterPIDForTesting(pid, triggerFunc)
+
+	// Wait a bit for the poller to get the initial hash
+	time.Sleep(2 * time.Second)
+
+	// Clear any initial notifications
+	for {
+		select {
+		case <-notifyCh:
+		default:
+			goto done
+		}
+	}
+done:
+
+	// Use dlopen to load a shared library which should trigger a maps change
+	var wg sync.WaitGroup
+	var detectedChange bool
+
+	// Start a goroutine to wait for the notification
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case detectedPID := <-notifyCh:
+			require.Equal(t, pid, detectedPID, "Expected notification for our PID")
+			detectedChange = true
+		case <-time.After(5 * time.Second):
+			t.Log("Timeout waiting for poller notification")
+		}
+	}()
+
+	// Load a library to trigger maps change
+	lib, err := dlopen.GetHandle([]string{
+		"/lib/x86_64-linux-gnu/libm.so.6",
+		"/usr/lib/x86_64-linux-gnu/libm.so.6",
+		"libm.so.6",
+	})
+	require.NoError(t, err, "Failed to open libm.so.6")
+
+	// Wait for the goroutine to complete
+	wg.Wait()
+
+	// Close the library
+	lib.Close()
+
+	require.True(t, detectedChange, "Poller should have detected the maps change from dlopen")
+}
+
+func TestIntegrationSingleShot(t *testing.T) {
+	if !testutils.IsRoot() {
+		t.Skip("This test requires root privileges")
+	}
+
+	// Override HasMultiUprobeSupport to force single-shot mode
+	multiUProbeOverride := false
+	util.SetTestOnlyMultiUprobeSupport(&multiUProbeOverride)
+	defer util.SetTestOnlyMultiUprobeSupport(nil)
+
+	// Create a context for the tracer
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Start the tracer with all tracers enabled
+	traceCh, trc := testutils.StartTracer(ctx, t,
+		tracertypes.AllTracers(),
+		&testutils.MockReporter{},
+		false)
+	defer trc.Close()
+
+	// Consume traces to prevent blocking
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-traceCh:
+				// Discard traces
+			}
+		}
+	}()
+
+	// retry a few times to get the metric, our process has to be detected and
+	// the rtld interpreter has to attach.
+	require.Eventually(t, func() bool {
+		// Get the initial metric value
+		initialCount := getEBPFMetricValue(trc, metrics.IDRtldMapCompleteHits)
+		//t.Logf("Initial rtld:map_complete metric count: %d", initialCount)
+
+		// Use dlopen to load a shared library
+		// libm is a standard math library that's always present
+		lib, err := dlopen.GetHandle([]string{
+			"/lib/x86_64-linux-gnu/libm.so.6",
+			"libm.so.6",
+		})
+		require.NoError(t, err, "Failed to open libm.so.6")
+		defer lib.Close()
+
+		// Get the metrics after dlopen
+		finalCount := getEBPFMetricValue(trc, metrics.IDRtldMapCompleteHits)
+		//t.Logf("Final rtld:map_complete metric count: %d", finalCount)
 
 		// Check that the metric was incremented
 		return finalCount > initialCount

--- a/interpreter/rtld/rtld_test.go
+++ b/interpreter/rtld/rtld_test.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/coreos/pkg/dlopen"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/ebpf-profiler/interpreter/rtld"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -180,6 +181,11 @@ done:
 func TestIntegrationSingleShot(t *testing.T) {
 	if !testutils.IsRoot() {
 		t.Skip("This test requires root privileges")
+	}
+
+	// Enable debug logging for CI debugging
+	if os.Getenv("DEBUG_TEST") != "" {
+		log.SetLevel(log.DebugLevel)
 	}
 
 	// Override HasMultiUprobeSupport to force single-shot mode

--- a/test/rtld-qemu/README.md
+++ b/test/rtld-qemu/README.md
@@ -1,0 +1,90 @@
+# RTLD QEMU Testing
+
+This directory contains scripts to test USDT/RTLD (runtime linker) mechanisms on different kernel versions using QEMU.
+
+## Prerequisites
+
+1. **Install required packages:**
+   ```bash
+   # For Ubuntu/Debian
+   sudo apt-get update
+   sudo apt-get install -y qemu-system-x86 debootstrap
+   ```
+
+2. **Download a kernel image:**
+   ```bash
+   # Download kernel 5.10 (pre-6.6, will use single-shot mode)
+   ./download-kernel.sh 5.10.217
+
+   # Or download kernel 6.8 (post-6.6, supports multi-uprobe)
+   ./download-kernel.sh 6.8.10
+   ```
+
+## Running Tests
+
+### Quick Test (All-in-one)
+```bash
+# Test with kernel 5.10 (tests fallback/single-shot mode)
+./build-and-run.sh 5.10.217
+
+# Test with kernel 6.8 (tests multi-uprobe mode)
+./build-and-run.sh 6.8.10
+```
+
+### Test Different Distributions
+```bash
+# Test with Ubuntu 24.04 (noble) - recommended, has USDT probes
+DISTRO=ubuntu RELEASE=noble ./build-and-run.sh 5.10.217
+
+# Test with Ubuntu 22.04 (jammy) - has USDT probes
+DISTRO=ubuntu RELEASE=jammy ./build-and-run.sh 5.10.217
+
+# Test with Ubuntu 20.04 (focal) - no USDT probes, uses fallback
+DISTRO=ubuntu RELEASE=focal ./build-and-run.sh 5.10.217
+
+# Test with Debian 11 (bullseye) - default, no USDT probes
+DISTRO=debian RELEASE=bullseye ./build-and-run.sh 5.10.217
+```
+
+## What These Tests Do
+
+1. **Creates a minimal rootfs** using debootstrap with:
+   - glibc (with ld.so that has USDT probes)
+   - Basic Linux userspace
+   - Our compiled rtld test binary
+
+2. **Boots QEMU** with:
+   - Selected kernel version
+   - Minimal initramfs containing our test environment
+   - Serial console output
+
+3. **Runs the RTLD tests**:
+   - `TestIntegration` - Tests USDT probe attachment
+   - `TestIntegrationPoller` - Tests polling fallback
+   - `TestIntegrationSingleShot` - Tests single-shot mode (pre-6.6 kernels)
+
+## Expected Behavior
+
+- **Kernel < 6.6**: Should use single-shot mode for USDT probes (if available), poller as fallback
+- **Kernel >= 6.6**: Should use multi-uprobe mode for USDT probes (if available)
+- All tests should pass regardless of kernel version
+- **USDT probe availability**: Ubuntu 22.04+ has rtld USDT probes, older versions use poller fallback
+
+## Available Kernels
+
+Check available kernels at: https://github.com/cilium/ci-kernels/pkgs/container/ci-kernels/versions
+
+Common versions to test:
+- 5.4.276 (Ubuntu 20.04 LTS)
+- 5.10.217 (Debian 11)
+- 5.15.159 (Ubuntu 22.04 LTS)
+- 6.1.91 (Debian 12)
+- 6.6.31 (First with multi-uprobe support)
+- 6.8.10 (Recent stable)
+
+## Troubleshooting
+
+1. **No KVM access**: The scripts will automatically use sudo if needed
+2. **Slow without KVM**: Without KVM acceleration, tests run slower but still work
+3. **Kernel not found**: Use `./download-kernel.sh <version>` to download
+4. **debootstrap fails**: Make sure you have internet access for package downloads

--- a/test/rtld-qemu/build-and-run.sh
+++ b/test/rtld-qemu/build-and-run.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+set -ex
+
+# Configuration
+KERNEL_VERSION="${1:-5.10.217}"
+QEMU_ARCH="${QEMU_ARCH:-x86_64}"
+DISTRO="${DISTRO:-ubuntu}"  # debian or ubuntu
+RELEASE="${RELEASE:-jammy}"  # jammy/noble for ubuntu (with USDT probes), bullseye for debian
+ROOTFS_DIR="rootfs"
+OUTPUT_DIR="output"
+KERN_DIR="${KERN_DIR:-ci-kernels}"
+CACHE_DIR="${CACHE_DIR:-/tmp/debootstrap-cache}"
+
+echo "Building rootfs with $DISTRO $RELEASE..."
+
+# Clean up previous builds
+rm -rf "$ROOTFS_DIR" "$OUTPUT_DIR"
+mkdir -p "$ROOTFS_DIR" "$OUTPUT_DIR" "$CACHE_DIR"
+
+# Determine debootstrap architecture
+DEBOOTSTRAP_ARCH="amd64"
+case "$QEMU_ARCH" in
+    x86_64)
+        DEBOOTSTRAP_ARCH="amd64"
+        ;;
+    aarch64)
+        DEBOOTSTRAP_ARCH="arm64"
+        ;;
+esac
+
+# Choose mirror based on distro and architecture
+if [[ "$DISTRO" == "ubuntu" ]]; then
+    # Ubuntu ARM64 packages are on ports.ubuntu.com
+    if [[ "$DEBOOTSTRAP_ARCH" == "arm64" ]]; then
+        MIRROR="http://ports.ubuntu.com/ubuntu-ports/"
+    else
+        MIRROR="http://archive.ubuntu.com/ubuntu/"
+    fi
+else
+    MIRROR="http://deb.debian.org/debian/"
+fi
+
+# Create minimal rootfs with debootstrap (requires sudo for chroot operations)
+echo "Running debootstrap to create $DISTRO $RELEASE rootfs for $DEBOOTSTRAP_ARCH..."
+sudo debootstrap --variant=minbase \
+    --arch="$DEBOOTSTRAP_ARCH" \
+    --cache-dir="$CACHE_DIR" \
+    "$RELEASE" "$ROOTFS_DIR" "$MIRROR"
+
+# Change ownership of rootfs to current user to avoid needing sudo for subsequent operations
+sudo chown -R "$(id -u):$(id -g)" "$ROOTFS_DIR"
+
+# Build the rtld test binary (must be dynamic for dlopen to work)
+echo "Building rtld test binary for $DISTRO $RELEASE $DEBOOTSTRAP_ARCH..."
+
+# Determine Go architecture
+GOARCH="amd64"
+case "$QEMU_ARCH" in
+    x86_64)
+        GOARCH="amd64"
+        ;;
+    aarch64)
+        GOARCH="arm64"
+        ;;
+esac
+
+# For cross-compilation or Ubuntu jammy/noble, local build works (host has compatible or newer glibc)
+# For older distros, would need Docker build (disabled by default for speed)
+if [[ "${USE_DOCKER}" == "1" ]] && command -v docker &> /dev/null; then
+    # Determine base image
+    if [[ "$DISTRO" == "ubuntu" ]]; then
+        BASE_IMAGE="ubuntu:${RELEASE}"
+    else
+        BASE_IMAGE="debian:${RELEASE}"
+    fi
+
+    # Build in container to match target glibc (slow, downloads Go)
+    echo "Using Docker to build with matching glibc version..."
+    docker run --rm \
+        -v "$(pwd)/../..:/workspace" \
+        -w /workspace/test/rtld-qemu \
+        --platform "linux/${DEBOOTSTRAP_ARCH}" \
+        "$BASE_IMAGE" \
+        bash -c "apt-get update -qq && apt-get install -y -qq wget libc6-dev gcc > /dev/null 2>&1 && \
+                 wget -q https://go.dev/dl/go1.24.7.linux-${GOARCH}.tar.gz && \
+                 tar -C /usr/local -xzf go1.24.7.linux-${GOARCH}.tar.gz && \
+                 export PATH=/usr/local/go/bin:\$PATH && \
+                 CGO_ENABLED=1 go test -c -o rtld.test ../../interpreter/rtld"
+else
+    # Local build with cross-compilation if needed
+    echo "Building locally for ${GOARCH}..."
+    CGO_ENABLED=1 GOARCH=${GOARCH} go test -c -o rtld.test \
+        ../../interpreter/rtld
+fi
+
+# Copy test binary into rootfs
+cp rtld.test "$ROOTFS_DIR/rtld.test"
+chmod +x "$ROOTFS_DIR/rtld.test"
+
+# List dynamic dependencies for debugging
+echo "Test binary dependencies:"
+ldd rtld.test || true
+
+# Create init script
+cat << 'EOF' > "$ROOTFS_DIR/init"
+#!/bin/sh
+echo "===== RTLD Test Environment ====="
+echo "Kernel: $(uname -r)"
+echo "Hostname: $(hostname)"
+
+# Find and display ld.so info
+LDSO=$(find /lib* /usr/lib* -name 'ld-linux*' -o -name 'ld-*.so*' 2>/dev/null | head -1)
+echo "ld.so location: $LDSO"
+if [ -n "$LDSO" ]; then
+    echo "ld.so version: $($LDSO --version | head -1)"
+fi
+
+# Find libm for dlopen test
+LIBM=$(find /lib* /usr/lib* -name 'libm.so*' 2>/dev/null | head -1)
+echo "libm.so location: $LIBM"
+
+echo "================================="
+
+# Mount required filesystems
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sys /sys 2>/dev/null || true
+mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true
+
+# Enable debug logging
+export DEBUG_TEST=1
+
+# Run the TestIntegrationSingleShot test specifically
+echo ""
+echo "Running RTLD TestIntegrationSingleShot test..."
+timeout -s KILL 60 /rtld.test -test.v -test.run='TestIntegrationSingleShot' -test.timeout=30s
+RESULT=$?
+
+if [ $RESULT -eq 0 ]; then
+    echo ""
+    echo "===== TEST PASSED ====="
+elif [ $RESULT -eq 137 ] || [ $RESULT -eq 124 ]; then
+    echo ""
+    echo "===== TEST TIMED OUT ====="
+else
+    echo ""
+    echo "===== TEST FAILED (exit code: $RESULT) ====="
+fi
+
+# Give time to see output before shutdown
+sleep 1
+
+# Try to cleanly shutdown QEMU
+# The sysrq 'o' trigger will power off the system
+echo o > /proc/sysrq-trigger 2>/dev/null
+
+# If sysrq doesn't work, force halt
+sleep 1
+poweroff -f 2>/dev/null || halt -f
+EOF
+chmod +x "$ROOTFS_DIR/init"
+
+# Create initramfs
+echo "Creating initramfs..."
+(cd "$ROOTFS_DIR" && find . | cpio -o -H newc | gzip > "../$OUTPUT_DIR/initramfs.gz")
+
+echo "Rootfs created: $OUTPUT_DIR/initramfs.gz ($(du -h $OUTPUT_DIR/initramfs.gz | cut -f1))"
+
+# Check if kernel exists
+if [[ ! -f "${KERN_DIR}/${KERNEL_VERSION}/vmlinuz" ]]; then
+    echo ""
+    echo "ERROR: Kernel ${KERNEL_VERSION} not found at ${KERN_DIR}/${KERNEL_VERSION}/vmlinuz"
+    echo ""
+    echo "To download kernel images:"
+    echo "  mkdir -p ci-kernels"
+    echo "  docker pull ghcr.io/cilium/ci-kernels:${KERNEL_VERSION}"
+    echo "  docker create --name kernel-extract ghcr.io/cilium/ci-kernels:${KERNEL_VERSION}"
+    echo "  docker cp kernel-extract:/boot ci-kernels/${KERNEL_VERSION}"
+    echo "  docker rm kernel-extract"
+    echo ""
+    exit 1
+fi
+
+# Use sudo if /dev/kvm isn't accessible by the current user
+sudo=""
+if [[ ! -r /dev/kvm || ! -w /dev/kvm ]]; then
+  sudo="sudo"
+fi
+
+# Determine additional QEMU args based on architecture
+additionalQemuArgs=""
+supportKVM=$(grep -E 'vmx|svm' /proc/cpuinfo || true)
+if [ "$supportKVM" ] && [ "$QEMU_ARCH" = "$(uname -m)" ]; then
+  additionalQemuArgs="-enable-kvm"
+fi
+
+case "$QEMU_ARCH" in
+    x86_64)
+        CONSOLE_ARG="console=ttyS0"
+        ;;
+    aarch64)
+        additionalQemuArgs+=" -machine virt -cpu max"
+        CONSOLE_ARG="console=ttyAMA0"
+        ;;
+esac
+
+echo ""
+echo "===== Starting QEMU with kernel ${KERNEL_VERSION} on ${QEMU_ARCH} ====="
+echo ""
+
+# Run QEMU
+${sudo} qemu-system-${QEMU_ARCH} ${additionalQemuArgs} \
+    -nographic \
+    -monitor none \
+    -serial mon:stdio \
+    -m 2G \
+    -kernel "${KERN_DIR}/${KERNEL_VERSION}/vmlinuz" \
+    -initrd "$OUTPUT_DIR/initramfs.gz" \
+    -append "${CONSOLE_ARG} init=/init quiet loglevel=3" \
+    -no-reboot \
+    -display none
+
+EXIT_CODE=$?
+
+# QEMU with sysrq poweroff returns 0 on clean shutdown
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "✅ Test completed successfully"
+    exit 0
+else
+    echo "❌ Test failed with QEMU exit code $EXIT_CODE"
+    exit $EXIT_CODE
+fi

--- a/test/rtld-qemu/download-kernel.sh
+++ b/test/rtld-qemu/download-kernel.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+KERNEL_VERSION="${1:-5.10.217}"
+QEMU_ARCH="${QEMU_ARCH:-x86_64}"
+KERN_DIR="${KERN_DIR:-ci-kernels}"
+
+# Map QEMU arch to Docker platform
+case "$QEMU_ARCH" in
+    x86_64)
+        DOCKER_PLATFORM="linux/amd64"
+        ;;
+    aarch64)
+        DOCKER_PLATFORM="linux/arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $QEMU_ARCH"
+        exit 1
+        ;;
+esac
+
+echo "Downloading kernel ${KERNEL_VERSION} for ${QEMU_ARCH} from ghcr.io/cilium/ci-kernels..."
+
+# Create directory
+mkdir -p "${KERN_DIR}"
+
+# Check if already exists
+if [[ -f "${KERN_DIR}/${KERNEL_VERSION}/vmlinuz" ]]; then
+    echo "Kernel ${KERNEL_VERSION} already exists at ${KERN_DIR}/${KERNEL_VERSION}/vmlinuz"
+    exit 0
+fi
+
+# Pull and extract kernel from Docker image using buildx (supports multi-arch)
+echo "Pulling Docker image for ${DOCKER_PLATFORM}..."
+echo "FROM ghcr.io/cilium/ci-kernels:${KERNEL_VERSION}" \
+  | docker buildx build --platform "${DOCKER_PLATFORM}" \
+    --quiet --pull --output="${KERN_DIR}" -
+mv "${KERN_DIR}/boot/" "${KERN_DIR}/${KERNEL_VERSION}/"
+
+if [[ -f "${KERN_DIR}/${KERNEL_VERSION}/vmlinuz" ]]; then
+    echo "✅ Kernel ${KERNEL_VERSION} downloaded successfully"
+    ls -la "${KERN_DIR}/${KERNEL_VERSION}/"
+else
+    echo "❌ Failed to download kernel"
+    exit 1
+fi

--- a/tools/coredump/ebpfmaps.go
+++ b/tools/coredump/ebpfmaps.go
@@ -8,7 +8,6 @@ import (
 	"math/bits"
 	"unsafe"
 
-	"github.com/cilium/ebpf/link"
 	"go.opentelemetry.io/ebpf-profiler/host"
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
@@ -266,7 +265,16 @@ func (emc *ebpfMapsCoredump) SupportsLPMTrieBatchOperations() bool {
 	return false
 }
 
-func (emc *ebpfMapsCoredump) AttachUSDTProbe(_ libpf.PID, _ string, _ pfelf.USDTProbe,
-	_ string) (link.Link, error) {
+func (emc *ebpfMapsCoredump) AttachUSDTProbes(_ libpf.PID, _, _ string, _ []pfelf.USDTProbe,
+	_ []uint64, _ []string, _ bool) (interpreter.LinkCloser, error) {
 	return nil, nil
+}
+
+func (emc *ebpfMapsCoredump) TriggerProcessSync(_ libpf.PID) error {
+	// No-op for coredump
+	return nil
+}
+
+func (emc *ebpfMapsCoredump) SetProcessSyncTrigger(func(pid libpf.PID)) {
+	// No-op for coredump
 }

--- a/util/util.go
+++ b/util/util.go
@@ -7,10 +7,14 @@ import (
 	"bytes"
 	"fmt"
 	"math/bits"
+	"sync"
 	"sync/atomic"
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/libpf/hash"
 	"golang.org/x/sys/unix"
 )
@@ -92,4 +96,88 @@ func GetCurrentKernelVersion() (major, minor, patch uint32, err error) {
 	}
 	_, _ = fmt.Fscanf(bytes.NewReader(uname.Release[:]), "%d.%d.%d", &major, &minor, &patch)
 	return major, minor, patch, nil
+}
+
+var (
+	// testOnlyMultiUprobeOverride allows tests to override HasMultiUprobeSupport
+	testOnlyMultiUprobeOverride *bool
+	// multiUprobeSupportCache caches the result of probing for multi-uprobe support
+	multiUprobeSupportOnce   sync.Once
+	multiUprobeSupportCached bool
+)
+
+// SetTestOnlyMultiUprobeSupport overrides HasMultiUprobeSupport for testing.
+// Pass nil to restore normal behavior.
+func SetTestOnlyMultiUprobeSupport(override *bool) {
+	testOnlyMultiUprobeOverride = override
+}
+
+// probeBpfGetAttachCookie tests if the kernel supports bpf_get_attach_cookie by attempting
+// to load a minimal BPF program that uses it. This is more reliable than checking kernel
+// versions since support can be backported.
+func probeBpfGetAttachCookie() bool {
+	// Create a minimal program that calls bpf_get_attach_cookie
+	// This is equivalent to libbpf's probe_kern_bpf_cookie function
+	insns := asm.Instructions{
+		// Call bpf_get_attach_cookie() - BPF_FUNC_get_attach_cookie = 80
+		asm.FnGetAttachCookie.Call(),
+		// Exit
+		asm.Return(),
+	}
+
+	spec := &ebpf.ProgramSpec{
+		Type:         ebpf.TracePoint,
+		Instructions: insns,
+		License:      "GPL",
+	}
+
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err != nil {
+		return false
+	}
+	if err := prog.Close(); err != nil {
+		log.Warnf("Failed to close test program: %v", err)
+	}
+	return true
+}
+
+// HasMultiUprobeSupport checks if the kernel supports uprobe multi-attach.
+// Multi-uprobes are needed because single-shot uprobes don't work for shared libraries.
+// This function probes for bpf_get_attach_cookie support, which is required for
+// multi-uprobes and was introduced alongside them in kernel 6.6.
+//
+// Note: This function requires CAP_BPF or CAP_SYS_ADMIN capabilities to load the probe
+// program. The profiler should already have these privileges.
+func HasMultiUprobeSupport() bool {
+	if testOnlyMultiUprobeOverride != nil {
+		return *testOnlyMultiUprobeOverride
+	}
+
+	multiUprobeSupportOnce.Do(func() {
+		multiUprobeSupportCached = probeBpfGetAttachCookie()
+	})
+
+	return multiUprobeSupportCached
+}
+
+// ProgArrayReferences returns a list of instructions which load a specified tail
+// call FD.
+func ProgArrayReferences(perfTailCallMapFD int, insns asm.Instructions) []int {
+	insNos := []int{}
+	for i := range insns {
+		ins := &insns[i]
+		if asm.OpCode(ins.OpCode.Class()) != asm.OpCode(asm.LdClass) {
+			continue
+		}
+		m := ins.Map()
+		if m == nil {
+			continue
+		}
+		if perfTailCallMapFD == m.FD() {
+			insNos = append(insNos, i)
+		}
+	}
+	return insNos
 }


### PR DESCRIPTION
Refactor AttachUSDTProbe to support multiple probes and cookies.
This enables more flexible USDT probe attachments and prepares
the infrastructure for future GPU and other system-wide probes.
