### PR TITLE
ci: cache luajit offset artifacts to dodge Docker Hub flakes

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -85,6 +85,13 @@ jobs:
           restore-keys: |
             coredumps-${{ matrix.target_arch }}
             coredumps-
+      - name: Cache luajit offset artifacts
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: /tmp/offsets_artifacts
+          key: luajit-offsets-${{ hashFiles('interpreter/luajit/offsets_test.go') }}
+          restore-keys: |
+            luajit-offsets-
       - name: Tests
         run: make test TARGET_ARCH=${{ matrix.target_arch }} GO_FLAGS="${{ matrix.go_flags }}"
 


### PR DESCRIPTION
## Summary

The luajit \`TestOffsets\` pulls 10 \`openresty/openresty\` images x 2 platforms per CI run to extract \`libluajit-5.1.so\`. Docker Hub rate-limiting and transient network errors make this flaky — pulls intermittently hang past the 600s test deadline.

The test already caches per-tag at \`/tmp/offsets_artifacts\`. Persisting that across CI runs via \`actions/cache\` eliminates the repeat pulls.

Cache key is hashed against \`offsets_test.go\` so adding/removing matrix entries invalidates the cache. The \`luajit-offsets-\` restore-key fallback means a matrix tweak only forces re-pulling the changed/new entries instead of the whole set.

## Test plan
- [ ] First CI run: cache miss, pulls images normally (same as today, hopefully without flake)
- [ ] Subsequent runs: cache hit, no Docker Hub traffic