### PR TITLE
Luajit: fix g2Dispatch extraction for openresty/openresty:alpine

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -10,3 +10,4 @@ wit
 ALS
 als
 checkin
+leas

--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -108,39 +108,104 @@ func (x *x86Extractor) findOffsetsFromLuaClose(b []byte) (glref, curL uint64, er
 //	0x000000000006a737 <+119>:   mov    0x10(%rbx),%rdi
 //	0x000000000006a73b <+123>:   call   0x16cf0
 //
-// Then we load the function 0x16cf0 and look where the rdi register is stashed,
-// usually rdx and then look for the first lea of rdx, ie:
-//
-// libluajit-5.1.so[0x16d4e] <+94>:  leaq   0xfa8(%rdx), %r10
-//
-// 0xfa8 is the g to dispatch offset.
+// Then we load the function 0x16cf0 and look at how it fills the per-G dispatch
+// table.  lj_dispatch_update emits an init loop bounded by two `lea OFS(%greg), %reg`
+// instructions whose displacements are the start and end of the dispatch table.
+// The smaller of the two displacements is normally the value we want.  The
+// compiler is free to emit the bounds in either order, and in some builds the
+// very first slot of the dispatch table is peeled off into a pre-loop
+// `mov %X, OFS(%greg)` store - in that case OFS sits a slot below the loop iter
+// LEA and that store's displacement is the canonical g2dispatch.
 // https://github.com/openresty/luajit2/blob/7952882d/src/lj_dispatch.c#L122
 func (x *x86Extractor) findG2DispatchOffsetFromLjDispatchUpdate(b []byte) (uint64, error) {
 	b, _ = xh.SkipEndBranch(b) //nolint:errcheck
-	var greg x86asm.Reg
+
+	type ref struct {
+		disp int64
+		pos  int
+	}
+	var (
+		greg   x86asm.Reg
+		leas   []ref
+		stores []ref
+		pos    int
+	)
+
 	for len(b) > 0 {
 		i, err := x86asm.Decode(b, 64)
 		if err != nil {
-			return 0, err
+			// Some builds put SSE/AVX instructions the decoder doesn't know
+			// later in lj_dispatch_update; stop scanning and decide from what
+			// we have so far rather than failing the whole load.
+			break
 		}
-		// Early on we stash rdi (g) in a register
+		// The dispatch table init lives in the prologue; once we hit a call
+		// we've left the region we care about.
+		if i.Op == x86asm.CALL {
+			break
+		}
 		if i.Op == x86asm.MOV {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Reg)
-			if ok1 && ok2 && a1 == x86asm.RDI {
-				greg = a0
+			// Early on we stash rdi (g) in a register.
+			if dst, dstOk := i.Args[0].(x86asm.Reg); dstOk {
+				if src, srcOk := i.Args[1].(x86asm.Reg); srcOk && src == x86asm.RDI {
+					greg = dst
+				}
+			}
+			// `mov %src, OFS(%greg)` - a peeled-off pre-loop store. Capture it
+			// so we can spot a dispatch-table first-slot store sitting one slot
+			// below the loop iter LEA.
+			if dst, ok := i.Args[0].(x86asm.Mem); ok && greg != 0 &&
+				dst.Base == greg && dst.Index == 0 && dst.Disp > 0 {
+				stores = append(stores, ref{disp: dst.Disp, pos: pos})
 			}
 		}
-		// Then load dispatch address relative to g
-		if i.Op == x86asm.LEA {
-			a1, ok := i.Args[1].(x86asm.Mem)
-			if ok && a1.Base == greg {
-				return uint64(a1.Disp), nil
+		if i.Op == x86asm.LEA && greg != 0 {
+			if src, ok := i.Args[1].(x86asm.Mem); ok && src.Base == greg &&
+				src.Index == 0 && src.Disp > 0 {
+				leas = append(leas, ref{disp: src.Disp, pos: pos})
 			}
 		}
 		b = b[i.Len:]
+		pos++
 	}
-	return 0, nil
+
+	if len(leas) == 0 {
+		return 0, nil
+	}
+	if len(leas) == 1 {
+		return uint64(leas[0].disp), nil
+	}
+
+	// Look for a pair of LEAs off greg whose displacements differ by no more
+	// than the dispatch table size (a few hundred bytes in every observed
+	// build).  Those are the bounds of the dispatch fill loop; the smaller
+	// disp is the loop iter start.
+	const maxDispatchTable = 1024
+	for i := 0; i < len(leas); i++ {
+		for j := i + 1; j < len(leas); j++ {
+			small := min(leas[i].disp, leas[j].disp)
+			big := max(leas[i].disp, leas[j].disp)
+			if big-small > maxDispatchTable {
+				continue
+			}
+			firstPos := min(leas[i].pos, leas[j].pos)
+			best := small
+			// If a slot just below the loop iter was filled by a peeled-off
+			// pre-loop store, prefer its displacement - that's the slot the
+			// DISPATCH register actually points at in JIT code.
+			for _, s := range stores {
+				if s.pos < firstPos && s.disp < small && small-s.disp <= 16 &&
+					s.disp < best {
+					best = s.disp
+				}
+			}
+			return uint64(best), nil
+		}
+	}
+
+	// No recognizable loop pair - fall back to the first LEA, matching the
+	// historical heuristic.
+	return uint64(leas[0].disp), nil
 }
 
 // Find first or second call address, the one whose first argument is 0x10 off of

--- a/interpreter/luajit/offsets_test.go
+++ b/interpreter/luajit/offsets_test.go
@@ -33,21 +33,33 @@ const (
 )
 
 func TestOffsets(t *testing.T) {
+	// g2Dispatch is the offset from G to the value the LJ JIT loads into the
+	// DISPATCH register (r14 on x86_64, r22 on aarch64). It's pinned per-build
+	// because a wrong value silently sends bad-G candidates to the userland
+	// triangulator and starves the eBPF JIT bootstrap path; only the rolling
+	// alpine build has ever drifted, but every tag is asserted here so the
+	// next time it does we catch it in CI rather than as flaky integration
+	// tests.
+	type expected struct {
+		amd64G2Dispatch uint16
+		arm64G2Dispatch uint16
+	}
 	for _, tc := range []struct {
 		tag  string
 		suf  string
 		fail bool
+		exp  expected
 	}{
-		{"1.13.6.2-alpine", "0", true},
-		{"1.15.8.3-alpine", "0", false},
-		{"1.17.8.2-alpine", "0", false},
-		{"1.19.9.1-focal", "0", false},
-		{"1.21.4.3-buster-fat", "0", false},
-		{"1.21.4.3-alpine", "0", false},
-		{"1.25.3.2-bullseye-fat", "ROLLING", false},
-		{"1.25.3.2-alpine", "ROLLING", false},
-		{"jammy", "ROLLING", false},
-		{"alpine", "ROLLING", false},
+		{"1.13.6.2-alpine", "0", true, expected{}},
+		{"1.15.8.3-alpine", "0", false, expected{amd64G2Dispatch: 0xf58}},
+		{"1.17.8.2-alpine", "0", false, expected{amd64G2Dispatch: 0xf58, arm64G2Dispatch: 0xf38}},
+		{"1.19.9.1-focal", "0", false, expected{amd64G2Dispatch: 0xfa0, arm64G2Dispatch: 0xf88}},
+		{"1.21.4.3-buster-fat", "0", false, expected{amd64G2Dispatch: 0xfa8, arm64G2Dispatch: 0xf90}},
+		{"1.21.4.3-alpine", "0", false, expected{amd64G2Dispatch: 0xfa8, arm64G2Dispatch: 0xf90}},
+		{"1.25.3.2-bullseye-fat", "ROLLING", false, expected{amd64G2Dispatch: 0xfa8, arm64G2Dispatch: 0xf90}},
+		{"1.25.3.2-alpine", "ROLLING", false, expected{amd64G2Dispatch: 0xfa8, arm64G2Dispatch: 0xf90}},
+		{"jammy", "ROLLING", false, expected{amd64G2Dispatch: 0xfc8, arm64G2Dispatch: 0xfc0}},
+		{"alpine", "ROLLING", false, expected{amd64G2Dispatch: 0xfc8, arm64G2Dispatch: 0xfc0}},
 	} {
 		for _, platform := range []string{"linux/amd64", "linux/arm64"} {
 			tag, suffix := tc.tag, tc.suf
@@ -81,7 +93,14 @@ func TestOffsets(t *testing.T) {
 				require.NoError(t, err)
 				require.NotZero(t, ljd.currentLOffset)
 				require.NotZero(t, ljd.g2Traces)
-				require.NotZero(t, ljd.g2Dispatch)
+				wantG2Dispatch := tc.exp.amd64G2Dispatch
+				if platform == "linux/arm64" {
+					wantG2Dispatch = tc.exp.arm64G2Dispatch
+				}
+				require.Equal(t, wantG2Dispatch, ljd.g2Dispatch,
+					"g2Dispatch mismatch: a wrong value here makes the eBPF JIT "+
+						"bootstrap emit bad-G candidates and starves luajit "+
+						"triangulation in CI")
 
 				od := offsetData{}
 				err = od.init(ef)


### PR DESCRIPTION
## Summary

`findG2DispatchOffsetFromLjDispatchUpdate` picks the first `lea OFS(%greg), %reg` it sees in `lj_dispatch_update` and returns its displacement. For most openresty builds the compiler emits the dispatch-table iter-start LEA first, so the value happens to match the canonical `r14 - G` that the JIT loads into DISPATCH. For the rolling `openresty/openresty:alpine` image, the compiler unrolls the dispatch-init loop by two and emits the loop-**end** LEA before the iter-start LEA, so we picked up `0x1290` instead of `0xfc8` — off by 712 bytes.

That bad value feeds the eBPF JIT bootstrap path (`G_ptr = r14 - g2dispatch`). On alpine every JIT sample handed userland a candidate G 712 bytes below the real one; userland rejected it on the first dereference. After that, the only way to triangulate was waiting for a sample to land in the libluajit interpreter range — and with a fib() workload that's almost 100% JIT-resident, the wait varied from a couple of seconds to over two minutes. CI's 10-minute go-test budget tipped over whenever a few subtests drew long waits in a row.

### Fix

Recognize the dispatch-fill loop as a pair of LEAs off greg whose displacements differ by no more than the dispatch-table size (~1 KB), take the smaller (iter-start) displacement, and let a peeled-off pre-loop `mov %X, OFS(%greg)` store sitting one slot below override it — that store fills the very first dispatch slot in builds that unroll. Fall back to the historical first-LEA result when no loop pair is found.

### Verification

The canonical `r14 - G` per build (from `lea OFS(%rbp), %r14` in `lj_vm_ffi_callback`):

| Build | canonical r14−G | extractor before | extractor after |
|---|---|---|---|
| 1.15.8.3-alpine | 0xf58 | 0xf58 ✓ | 0xf58 ✓ |
| 1.17.8.2-alpine | 0xf58 | 0xf58 ✓ | 0xf58 ✓ |
| 1.19.9.1-focal | 0xfa0 | 0xfa0 ✓ | 0xfa0 ✓ |
| 1.21.4.3-{alpine,buster-fat} | 0xfa8 | 0xfa8 ✓ | 0xfa8 ✓ |
| 1.25.3.2-{alpine,bullseye-fat} | 0xfa8 | 0xfa8 ✓ | 0xfa8 ✓ |
| jammy (ROLLING) | 0xfc8 | 0xfc8 ✓ | 0xfc8 ✓ |
| **alpine (ROLLING)** | **0xfc8** | **0x1290 ✗** | **0xfc8 ✓** |

`TestOffsets` is hardened to assert these exact values per tag/arch (was just `NotZero`), so the next time a rolling tag drifts we fail a unit test instead of an integration test.

Local `TestIntegration/fib/alpine`: 8 consecutive runs at 3.5–4.8 s with no "bad-G deleted" warnings. Before the fix: 17–133 s with frequent rejections.

## Test plan
- [x] `go test -run TestOffsets ./interpreter/luajit/` — passes for all 18 tag/arch combos with new exact-value assertions
- [x] `go test -run 'TestSynchronizeMappings|TestX86LuaClose|TestStructure|TestParseVarinfo|TestFiles' ./interpreter/luajit/` — all pass
- [x] `sudo go test -run 'TestIntegration/fib/^alpine$' ./interpreter/luajit/` — 8 consecutive 3.5–4.8 s passes locally
- [x] Sanity-checked `1.17.8.2-alpine`, `1.25.3.2-bullseye`, `jammy` — 3.6–4.4 s each, no regression