### PR TITLE
[luajit] Extend jit_checktrace disassembler for ADD/SUB

### DIFF
--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -294,21 +294,36 @@ func (x *x86Extractor) findLjDispatchUpdateAddr(b []byte, addr uint64) (uint64, 
 func (x *x86Extractor) findG2TracesOffsetFromChecktrace(b []byte) (uint64, error) {
 	b, _ = xh.SkipEndBranch(b) //nolint:errcheck
 	var Greg x86asm.Reg
+	var offset int64
 	for len(b) > 0 {
 		i, err := x86asm.Decode(b, 64)
 		if err != nil {
 			return 0, err
 		}
-		if i.Op == x86asm.MOV {
+		switch i.Op {
+		case x86asm.MOV:
 			a1, ok := i.Args[1].(x86asm.Mem)
 			if ok {
 				// glref offset is 0x10
 				if a1.Disp == 0x10 {
 					Greg = i.Args[0].(x86asm.Reg)
 				} else if a1.Base == Greg {
-					return uint64(a1.Disp), nil
+					return uint64(a1.Disp + offset), nil
 				}
 			}
+		case x86asm.SUB, x86asm.ADD:
+			r, ok := i.Args[0].(x86asm.Reg)
+			if ok && r == Greg {
+				delta, ok := i.Args[1].(x86asm.Imm)
+				if ok {
+					if i.Op == x86asm.SUB {
+						offset -= int64(delta)
+					} else {
+						offset += int64(delta)
+					}
+				}
+			}
+
 		}
 		b = b[i.Len:]
 	}


### PR DESCRIPTION
Some binaries in the wild have applied a translation to this register before using it to get `traces`, which of course we need to undo.