### PR TITLE
luajit: migrate x86 lua_close & jit_checktrace extractors to asm/amd

### DIFF
--- a/asm/amd/interpreter.go
+++ b/asm/amd/interpreter.go
@@ -98,6 +98,25 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 				i.Regs.setX86asm(dst, expression.Add(left, right))
 			}
 		}
+	case x86asm.SUB:
+		// SUB is ADD with the right operand negated (-1 * x). Multiply/Add fold
+		// the immediate case, so `sub reg, imm` cancels a later `+imm`.
+		if dst, ok := inst.Args[0].(x86asm.Reg); ok {
+			left := i.Regs.GetX86(dst)
+			var right expression.Expression
+			switch src := inst.Args[1].(type) {
+			case x86asm.Imm:
+				right = expression.Imm(uint64(src))
+			case x86asm.Reg:
+				right = i.Regs.GetX86(src)
+			case x86asm.Mem:
+				right = expression.MemWithSegment(src.Segment, i.MemArg(src), inst.MemBytes)
+			}
+			if right != nil {
+				neg := expression.Multiply(expression.Imm(^uint64(0)), right)
+				i.Regs.setX86asm(dst, expression.Add(left, neg))
+			}
+		}
 	case x86asm.SHL:
 		if dst, ok := inst.Args[0].(x86asm.Reg); ok {
 			if src, imm := inst.Args[1].(x86asm.Imm); imm {

--- a/asm/amd/interpreter.go
+++ b/asm/amd/interpreter.go
@@ -139,7 +139,7 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 				if src.Base == x86asm.RIP {
 					// For RIP-relative, the address is RIP + displacement.
 					// RIP points to the already updated next instruction.
-					v = expression.Add(i.Regs.GetX86(x86asm.RIP), expression.Imm(uint64(src.Disp)))
+					v = expression.Add(i.Regs.GetX86(x86asm.RIP), immFromDisp(src.Disp))
 				} else {
 					v = i.MemArg(src)
 				}
@@ -182,10 +182,21 @@ func (i *Interpreter) Step() (x86asm.Inst, error) {
 	return inst, nil
 }
 
+// immFromDisp builds an immediate from an x86asm displacement. x86asm doesn't
+// sign-extend 32-bit displacements: they arrive zero-extended in
+// [0, math.MaxUint32], so recover the sign. A full 64-bit displacement (the
+// moffs64 absolute MOV form) is already the intended value and passes through.
+func immFromDisp(disp int64) expression.Expression {
+	if uint64(disp) <= math.MaxUint32 {
+		return expression.Imm(uint64(int32(disp)))
+	}
+	return expression.Imm(uint64(disp))
+}
+
 func (i *Interpreter) MemArg(src x86asm.Mem) expression.Expression {
 	vs := make([]expression.Expression, 0, 3)
 	if src.Disp != 0 {
-		vs = append(vs, expression.Imm(uint64(src.Disp)))
+		vs = append(vs, immFromDisp(src.Disp))
 	}
 	if src.Base != 0 {
 		vs = append(vs, i.Regs.GetX86(src.Base))

--- a/asm/amd/interpreter_test.go
+++ b/asm/amd/interpreter_test.go
@@ -173,6 +173,44 @@ func TestMoveSignExtend(t *testing.T) {
 	require.True(t, i.Regs.Get(RAX).Match(pattern))
 }
 
+func TestSubImmediate(t *testing.T) {
+	// 0000 	48 BA 00 10 00 00 00 00 00 00 	mov rdx, 0x1000
+	// 000a 	48 83 EA 0C 	sub rdx, 0xC
+	// 000e 	48 8B 92 3C 04 00 00 	mov rdx, qword ptr [rdx + 0x43C]
+	//
+	// The CPU effectively executes mov rdx, [0x1000 - 0xc + 0x43c] = [0x1430].
+	// Symbolically we expect: prev + (-0xc) + 0x43c collapses to prev + 0x430,
+	// so RDX after the third instruction is Mem8(Imm(0x1000 + 0x430)) = Mem8(Imm(0x1430)).
+	it := NewInterpreterWithCode([]byte{
+		0x48, 0xba, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x48, 0x83, 0xea, 0x0c,
+		0x48, 0x8b, 0x92, 0x3c, 0x04, 0x00, 0x00,
+	})
+	_, err := it.Loop()
+	require.ErrorIs(t, err, io.EOF)
+	assertEval(t, it.Regs.Get(RDX), expression.Mem8(expression.Imm(0x1430)))
+}
+
+func TestSubRegister(t *testing.T) {
+	// 0000 	48 B8 00 10 00 00 00 00 00 00 	mov rax, 0x1000
+	// 000a 	48 B9 0C 00 00 00 00 00 00 00 	mov rcx, 0xc
+	// 0014 	48 29 C8 	sub rax, rcx
+	// 0017 	48 8B 80 3C 04 00 00 	mov rax, qword ptr [rax + 0x43c]
+	//
+	// The register being subtracted (%rcx) holds a known immediate, so -1*rcx
+	// folds and rax collapses to [0x1000 - 0xc + 0x43c] = [0x1430] - same as
+	// the imm form, exercising the SUB Reg path.
+	it := NewInterpreterWithCode([]byte{
+		0x48, 0xb8, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x48, 0xb9, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x48, 0x29, 0xc8,
+		0x48, 0x8b, 0x80, 0x3c, 0x04, 0x00, 0x00,
+	})
+	_, err := it.Loop()
+	require.ErrorIs(t, err, io.EOF)
+	assertEval(t, it.Regs.Get(RAX), expression.Mem8(expression.Imm(0x1430)))
+}
+
 func TestRIPRelativeAddressing(t *testing.T) {
 	// Test case: mov 0x10512121(%rip),%rcx
 	code := []byte{

--- a/asm/amd/interpreter_test.go
+++ b/asm/amd/interpreter_test.go
@@ -256,3 +256,55 @@ func TestRIPRelativeAddressing(t *testing.T) {
 
 	assertEval(t, rcxVal, expectedExpr)
 }
+
+func TestDisplacementSignExtension(t *testing.T) {
+	// x86asm zero-extends 32-bit displacements, so immFromDisp must recover the
+	// sign for backward references while leaving a full 64-bit moffs address
+	// intact. Cover both immFromDisp call sites (MemArg and the RIP-relative
+	// MOV special case) plus the moffs64 form.
+	mem8 := func(addr uint64) expression.Expression {
+		return expression.ZeroExtend(expression.Mem(expression.Imm(addr), 8), 64)
+	}
+	for _, tc := range []struct {
+		name string
+		code []byte
+		base uint64
+		reg  x86asm.Reg
+		want expression.Expression
+	}{
+		{
+			// lea -0x1d13(%rip),%rdx at 0x6d96c -> 0x6bc60 (MemArg path).
+			name: "lea-negative-rip",
+			code: []byte{0x48, 0x8d, 0x15, 0xed, 0xe2, 0xff, 0xff},
+			base: 0x6d96c,
+			reg:  x86asm.RDX,
+			want: expression.Imm(0x6bc60),
+		},
+		{
+			// mov -0x1234(%rip),%rax at 0x10000: RIP=0x10007 -> [0xedd3]
+			// (RIP-relative MOV path, not MemArg).
+			name: "mov-negative-rip",
+			code: []byte{0x48, 0x8b, 0x05, 0xcc, 0xed, 0xff, 0xff},
+			base: 0x10000,
+			reg:  x86asm.RAX,
+			want: mem8(0xedd3),
+		},
+		{
+			// movabs rax, [0x1122334455667788]: the moffs64 form carries a full
+			// 64-bit address that must not be truncated to 32 bits.
+			name: "moffs64-full-width",
+			code: []byte{0x48, 0xa1, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11},
+			base: 0,
+			reg:  x86asm.RAX,
+			want: mem8(0x1122334455667788),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			it := NewInterpreterWithCode(tc.code)
+			it.CodeAddress = expression.Imm(tc.base)
+			_, err := it.Step()
+			require.NoError(t, err)
+			assertEval(t, it.Regs.GetX86(tc.reg), tc.want)
+		})
+	}
+}

--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -258,41 +258,39 @@ func (x *x86Extractor) findG2DispatchOffsetFromLjDispatchUpdate(b []byte) (uint6
 //
 //nolint:lll
 func (x *x86Extractor) findLjDispatchUpdateAddr(b []byte, addr uint64) (uint64, error) {
-	b, ip := xh.SkipEndBranch(b)
-	var Lreg x86asm.Reg
-	rdiHasG := false
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
-		if err != nil {
-			return 0, err
-		}
-		if i.Op == x86asm.MOV {
-			if a1, ok1 := i.Args[1].(x86asm.Reg); ok1 && a1 == x86asm.RDI {
-				if a0, ok0 := i.Args[0].(x86asm.Reg); ok0 {
-					Lreg = a0
-				}
-			}
-			if a0, ok := i.Args[0].(x86asm.Reg); ok && a0 == x86asm.RDI {
-				if a1, ok1 := i.Args[1].(x86asm.Mem); ok1 {
-					// Look for: movq   0x10(%rbx), %rdi
-					if a1.Base == Lreg && a1.Disp == 0x10 {
-						rdiHasG = true
-					}
-				}
-			}
-		}
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(addr)
+	// L is initial RDI (SysV first arg). lj_dispatch_update's first arg is G,
+	// reached via L->glref at offset 0x10. We don't care which register the
+	// compiler parks L in - symbolic tracking handles the chain.
+	L := it.Regs.GetX86(x86asm.RDI)
+	G := expression.Mem8(expression.Add(L, expression.Imm(0x10)))
 
-		if i.Op == x86asm.CALL && rdiHasG {
-			offset := int64(i.Args[0].(x86asm.Rel))
-			callAddr := int64(addr) + ip + offset + int64(i.Len)
-			// TODO: make sure callAddr is within .text bounds?
-			if callAddr < 0 {
-				return 0, errors.New("invalid call address")
+	for {
+		inst, err := it.Step()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
 			}
-			return uint64(callAddr), nil
+			return 0, fmt.Errorf("scanning function body: %w", err)
 		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+		if inst.Op != x86asm.CALL {
+			continue
+		}
+		if !it.Regs.GetX86(x86asm.RDI).Match(G) {
+			continue
+		}
+		rel, ok := inst.Args[0].(x86asm.Rel)
+		if !ok {
+			continue
+		}
+		// it.PC() is the offset past the CALL within the interpreter's bytes,
+		// which equals the offset in the caller's bytes since we started at 0.
+		callAddr := int64(addr) + int64(it.PC()) + int64(rel)
+		if callAddr < 0 {
+			return 0, errors.New("invalid call address")
+		}
+		return uint64(callAddr), nil
 	}
 	return 0, errors.New("lj_dispatch_update addr not found")
 }
@@ -403,37 +401,41 @@ func (x *x86Extractor) callExists(b []byte, baseAddr, targetCall int64) (bool, e
 //
 //nolint:lll
 func (x *x86Extractor) find2ndArgTo2ndPushClosureCall(b []byte, baseAddr, targetCall int64) (uint64, error) {
-	var leaRsi int64
-	calls := 2
-	b, ip := xh.SkipEndBranch(b)
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(uint64(baseAddr))
+	callsLeft := 2
+
+	for {
+		inst, err := it.Step()
 		if err != nil {
-			return 0, err
-		}
-		if i.Op == x86asm.LEA {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Mem)
-			if ok1 && ok2 {
-				if a0 == x86asm.RSI && a1.Base == x86asm.RIP {
-					leaRsi = calcRipRelativeAddr(a1, baseAddr, ip+int64(i.Len))
-				}
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			return 0, fmt.Errorf("scanning function body: %w", err)
 		}
-		if i.Op == x86asm.CALL {
-			a0, ok := i.Args[0].(x86asm.Rel)
-			if ok {
-				callAddr := baseAddr + ip + int64(i.Len) + int64(a0)
-				if callAddr == targetCall {
-					calls--
-					if calls == 0 {
-						return uint64(leaRsi), nil
-					}
-				}
-			}
+		if inst.Op != x86asm.CALL {
+			continue
 		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+		rel, ok := inst.Args[0].(x86asm.Rel)
+		if !ok {
+			continue
+		}
+		if baseAddr+int64(it.PC())+int64(rel) != targetCall {
+			continue
+		}
+		callsLeft--
+		if callsLeft > 0 {
+			continue
+		}
+		// Each LEA $disp(%rip), %rsi the interpreter has executed sets RSI to
+		// a concrete absolute address (CodeAddress + pc_after_lea + disp).
+		// Read whatever RSI currently holds; if the immediate-preceding LEA
+		// canonicalized to an Imm it will match.
+		rsiCap := expression.NewImmediateCapture("rsi")
+		if !it.Regs.GetX86(x86asm.RSI).Match(rsiCap) {
+			return 0, errors.New("RSI is not a concrete address at the 2nd matching call")
+		}
+		return rsiCap.CapturedValue(), nil
 	}
 	return 0, errors.New("failed to find rip relative lea instruction stored in rsi")
 }
@@ -489,8 +491,6 @@ func skipCallsAABA(b []byte, ip, baseAddr int64) ([]byte, int64, error) {
 // 6d973:	48 8d 35 1c a2 00 00 	lea    0xa21c(%rip),%rsi     # 77b96 <lj_lib_init_debug+0x236>
 // 6d97a:	e8 a1 28 ff ff       	call   60220 <lj_lib_prereg>
 func (x *x86Extractor) find3rdArgToLibPreregCall(b []byte, baseAddr int64) (uint64, error) {
-	var rdxAddr int64
-	calls := 3
 	b, ip := xh.SkipEndBranch(b)
 	// Skip the lua_push* call sequence (and all the preceding calls which varies depending on
 	// inlining).
@@ -509,40 +509,39 @@ func (x *x86Extractor) find3rdArgToLibPreregCall(b []byte, baseAddr int64) (uint
 	// libluajit-5.1.so[0x700dd] <+189>: movl   $0x12, %edx
 	// libluajit-5.1.so[0x700e2] <+194>: leaq   0x9b0a(%rip), %rsi
 	// libluajit-5.1.so[0x700e9] <+201>: callq  0x9af0         ; symbol stub for: lua_pushlstring
-	var err error
-	b, ip, err = skipCallsAABA(b, ip, baseAddr)
+	b, ip, err := skipCallsAABA(b, ip, baseAddr)
 	if err != nil {
 		return 0, err
 	}
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
+
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(uint64(baseAddr + ip))
+	callsLeft := 3
+
+	for {
+		inst, err := it.Step()
 		if err != nil {
-			return 0, err
-		}
-		// Some compilers will use MOV instead of LEA
-		if i.Op == x86asm.MOV {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			if ok1 && a0 == x86asm.EDX {
-				rdxAddr = int64(i.Args[1].(x86asm.Imm))
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			return 0, fmt.Errorf("scanning function body: %w", err)
 		}
-		if i.Op == x86asm.LEA {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Mem)
-			if ok1 && ok2 {
-				if a0 == x86asm.RDX && a1.Base == x86asm.RIP {
-					rdxAddr = calcRipRelativeAddr(a1, baseAddr, ip+int64(i.Len))
-				}
-			}
+		if inst.Op != x86asm.CALL {
+			continue
 		}
-		if i.Op == x86asm.CALL {
-			calls--
-			if calls == 0 {
-				return uint64(rdxAddr), nil
-			}
+		callsLeft--
+		if callsLeft > 0 {
+			continue
 		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+		// At the 3rd call after AABA, RDX should hold the luaopen_jit_util
+		// address - either via `lea $rip-rel, %rdx` (canonicalized to a
+		// concrete Imm by the interpreter) or `mov $imm, %edx` (some
+		// compilers).
+		rdxCap := expression.NewImmediateCapture("rdx")
+		if !it.Regs.GetX86(x86asm.RDX).Match(rdxCap) {
+			return 0, errors.New("RDX is not a concrete value at the 3rd post-AABA call")
+		}
+		return rdxCap.CapturedValue(), nil
 	}
 	return 0, errors.New("failed to find 3rd arg to lj_lib_prereg call")
 }
@@ -558,39 +557,20 @@ func (x *x86Extractor) find3rdArgToLibPreregCall(b []byte, baseAddr int64) (uint
 // bbbe:	48 83 c4 08          	add    $0x8,%rsp
 // bbc2:	c3                   	ret
 func (x *x86Extractor) find4thArgToLibRegCall(b []byte, baseAddr int64) (int64, error) {
-	var ip int64
-	b, ip = xh.SkipEndBranch(b)
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
-		if err != nil {
-			return 0, err
-		}
-		if i.Op == x86asm.LEA {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Mem)
-			if ok1 && ok2 {
-				// RCX is 4th arg
-				if a0 == x86asm.RCX && a1.Base == x86asm.RIP {
-					return calcRipRelativeAddr(a1, baseAddr, ip+int64(i.Len)), nil
-				}
-			}
-		}
-		if i.Op == x86asm.MOV {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Imm)
-			if ok1 && ok2 && a0 == x86asm.ECX {
-				return int64(a1), nil
-			}
-		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(uint64(baseAddr))
+	// luaopen_jit_util's body is: set up call args (RCX via either
+	// `lea $rip-rel, %rcx` or `mov $imm, %ecx`), then call lj_lib_register.
+	// Step until that CALL, then read RCX symbolically.
+	_, err := it.LoopWithBreak(func(op x86asm.Inst) bool {
+		return op.Op == x86asm.CALL
+	})
+	if err != nil && err != io.EOF {
+		return 0, err
 	}
-	return 0, errors.New("failed to find 4th arg to lj_reg call")
-}
-
-func calcRipRelativeAddr(a1 x86asm.Mem, baseAddr, ip int64) int64 {
-	// Disp is an int64 but its not set properly and negative numbers
-	// are 32 bit.  TODO: This is a bug that should be created/looked up.
-	disp := int32(a1.Disp)
-	return baseAddr + ip + int64(disp)
+	rcxCap := expression.NewImmediateCapture("rcx")
+	if !it.Regs.GetX86(x86asm.RCX).Match(rcxCap) {
+		return 0, errors.New("failed to find 4th arg to lj_reg call")
+	}
+	return int64(rcxCap.CapturedValue()), nil
 }

--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -13,6 +13,8 @@ package luajit // import "go.opentelemetry.io/ebpf-profiler/interpreter/luajit"
 
 import (
 	"errors"
+	"fmt"
+	"io"
 
 	"go.opentelemetry.io/ebpf-profiler/asm/amd"
 	"go.opentelemetry.io/ebpf-profiler/asm/expression"
@@ -75,7 +77,10 @@ func (x *x86Extractor) findOffsetsFromLuaClose(b []byte) (glref, curL uint64, er
 	for {
 		inst, stepErr := it.Step()
 		if stepErr != nil {
-			break
+			if errors.Is(stepErr, io.EOF) {
+				break
+			}
+			return 0, 0, fmt.Errorf("scanning lua_close for glref store: %w", stepErr)
 		}
 		if inst.Op != x86asm.MOV {
 			continue
@@ -305,41 +310,43 @@ func (x *x86Extractor) findLjDispatchUpdateAddr(b []byte, addr uint64) (uint64, 
 // libluajit-5.1.so[0x6379f] <+31>: jbe    0x637ae        ; <+46> at lib_jit.c:304:1
 // ----------- 0x430 is the G to J->traces offset
 // libluajit-5.1.so[0x637a1] <+33>: movq   0x430(%rdx), %rdx
+//
+// Some builds apply an ADD/SUB constant to the register holding G before the
+// final load; the symbolic interpreter folds those into the address expression
+// for free, so the captured displacement is the true G->traces offset.
 func (x *x86Extractor) findG2TracesOffsetFromChecktrace(b []byte) (uint64, error) {
-	b, _ = xh.SkipEndBranch(b) //nolint:errcheck
-	var Greg x86asm.Reg
-	var offset int64
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
-		if err != nil {
-			return 0, err
-		}
-		switch i.Op {
-		case x86asm.MOV:
-			a1, ok := i.Args[1].(x86asm.Mem)
-			if ok {
-				// glref offset is 0x10
-				if a1.Disp == 0x10 {
-					Greg = i.Args[0].(x86asm.Reg)
-				} else if a1.Base == Greg {
-					return uint64(a1.Disp + offset), nil
-				}
-			}
-		case x86asm.SUB, x86asm.ADD:
-			r, ok := i.Args[0].(x86asm.Reg)
-			if ok && r == Greg {
-				delta, ok := i.Args[1].(x86asm.Imm)
-				if ok {
-					if i.Op == x86asm.SUB {
-						offset -= int64(delta)
-					} else {
-						offset += int64(delta)
-					}
-				}
-			}
+	it := amd.NewInterpreterWithCode(b)
+	// L is initial RDI; G is L->glref. glref is hard-wired at 0x10 in the
+	// LJ_GC64 layout (findOffsetsFromLuaClose enforces this assumption
+	// before extractOffsets gets here).
+	L := it.Regs.GetX86(x86asm.RDI)
+	G := expression.Mem8(expression.Add(L, expression.Imm(0x10)))
+	tracesCap := expression.NewImmediateCapture("g2traces")
+	pattern := expression.Mem8(expression.Add(G, tracesCap))
 
+	for {
+		inst, err := it.Step()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return 0, fmt.Errorf("scanning jit_checktrace for G->traces load: %w", err)
 		}
-		b = b[i.Len:]
+		// We're looking for a load from [G + disp] into a register; the
+		// destination's new symbolic value is what we match against.
+		if inst.Op != x86asm.MOV {
+			continue
+		}
+		dstReg, dstIsReg := inst.Args[0].(x86asm.Reg)
+		if !dstIsReg {
+			continue
+		}
+		if _, srcIsMem := inst.Args[1].(x86asm.Mem); !srcIsMem {
+			continue
+		}
+		if it.Regs.GetX86(dstReg).Match(pattern) {
+			return tracesCap.CapturedValue(), nil
+		}
 	}
 	return 0, errors.New("offset not found")
 }

--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -14,6 +14,8 @@ package luajit // import "go.opentelemetry.io/ebpf-profiler/interpreter/luajit"
 import (
 	"errors"
 
+	"go.opentelemetry.io/ebpf-profiler/asm/amd"
+	"go.opentelemetry.io/ebpf-profiler/asm/expression"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 	xh "go.opentelemetry.io/ebpf-profiler/x86helpers"
 	"golang.org/x/arch/x86/x86asm"
@@ -48,56 +50,68 @@ which is a dynamic public symbol that should be in all binaries of LuaJIT includ
 	0x0000000000016dae <+46>:    mov    %rbx,%rdi
 	0x0000000000016db1 <+49>:    movq   $0x0,0x170(%rbp)  ; 0x170 is curLOffset
 */
+// findOffsetsFromLuaClose recovers glref (offset of G in L) and curL (offset of
+// cur_L in G) from lua_close. The prologue looks like:
+//
+//	mov 0x10(%rdi), %rbx       ; %rbx = L->glref  (i.e. G)
+//	...
+//	mov %rsi, 0x158(%rbx)      ; G->cur_L = 0  (%rsi previously zeroed via XOR)
+//
+// We drive the asm/amd symbolic interpreter so that whichever register ends up
+// holding G keeps its provenance (Mem8([L + glref])) regardless of MOV chains,
+// 32/64-bit register aliasing, or which register the compiler picks. We then
+// stop at the first memory store of zero whose base register matches that
+// expression and read both offsets off it.
+//
 //nolint:nonamedreturns
 func (x *x86Extractor) findOffsetsFromLuaClose(b []byte) (glref, curL uint64, err error) {
-	b, _ = xh.SkipEndBranch(b) //nolint:errcheck
-	var greg x86asm.Reg
-	var zeroReg x86asm.Reg
-	for len(b) > 0 {
-		var i x86asm.Inst
-		i, err = x86asm.Decode(b, 64)
-		if err != nil {
-			return 0, 0, err
+	it := amd.NewInterpreterWithCode(b)
+	// SysV ABI passes lua_State *L in RDI. The interpreter initializes every
+	// register to a fresh Named expression, so RDI's initial value IS our L.
+	// expression.Match uses pointer equality for *named, so this same instance
+	// is what we'll match against.
+	L := it.Regs.GetX86(x86asm.RDI)
+
+	for {
+		inst, stepErr := it.Step()
+		if stepErr != nil {
+			break
 		}
-		if i.Op == x86asm.XOR {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Reg)
-			if ok1 && ok2 && a0 == a1 {
-				zeroReg = a0
-			}
+		if inst.Op != x86asm.MOV {
+			continue
 		}
-		if i.Op == x86asm.MOV {
-			if greg == 0 {
-				a0, ok1 := i.Args[0].(x86asm.Reg)
-				a1, ok2 := i.Args[1].(x86asm.Mem)
-				if ok1 && ok2 && a1.Base == x86asm.RDI {
-					greg = a0
-					glref = uint64(a1.Disp)
-				}
-			} else {
-				a0, ok1 := i.Args[0].(x86asm.Mem)
-				if ok1 && sameReg(a0.Base, greg) {
-					imm, ok2 := i.Args[1].(x86asm.Imm)
-					if ok2 && imm == 0 {
-						curL = uint64(a0.Disp)
-						return glref, curL, nil
-					}
-					r1, ok2 := i.Args[1].(x86asm.Reg)
-					if ok2 && sameReg(r1, zeroReg) {
-						curL = uint64(a0.Disp)
-						return glref, curL, nil
-					}
-				}
-				// If Greg is dest error
-				if r0, ok := i.Args[0].(x86asm.Reg); ok && sameReg(r0, greg) {
-					err = errors.New("parse error, register holding G was clobbered")
-					return 0, 0, err
-				}
-			}
+		dst, isMem := inst.Args[0].(x86asm.Mem)
+		if !isMem || dst.Base == 0 {
+			continue
 		}
-		b = b[i.Len:]
+		if !isZeroOperand(inst.Args[1], &it.Regs) {
+			continue
+		}
+		// The interpreter doesn't model memory stores, so the symbolic value of
+		// the destination's base register is its value as of just before the
+		// store - exactly what we want. We expect G = Mem8([L + glref]).
+		glrefCap := expression.NewImmediateCapture("glref")
+		if it.Regs.GetX86(dst.Base).Match(
+			expression.Mem8(expression.Add(L, glrefCap)),
+		) {
+			return glrefCap.CapturedValue(), uint64(dst.Disp), nil
+		}
 	}
 	return 0, 0, errors.New("find offsets from lua_close failed")
+}
+
+// isZeroOperand reports whether arg currently evaluates to zero - either as a
+// literal immediate or as a register the symbolic interpreter has determined
+// holds zero (typically from xor reg, reg).
+func isZeroOperand(arg x86asm.Arg, regs *amd.Registers) bool {
+	switch v := arg.(type) {
+	case x86asm.Imm:
+		return v == 0
+	case x86asm.Reg:
+		cap := expression.NewImmediateCapture("zero")
+		return regs.GetX86(v).Match(cap) && cap.CapturedValue() == 0
+	}
+	return false
 }
 
 // This is different in most builds and we need to get it from stripped binaries.
@@ -572,29 +586,4 @@ func calcRipRelativeAddr(a1 x86asm.Mem, baseAddr, ip int64) int64 {
 	// are 32 bit.  TODO: This is a bug that should be created/looked up.
 	disp := int32(a1.Disp)
 	return baseAddr + ip + int64(disp)
-}
-
-// If we're dealing with 32bit values compilers will use R or E prefix
-// interchangeably (E refs are just zero padded).
-func sameReg(r1, r2 x86asm.Reg) bool {
-	if r1 == r2 {
-		return true
-	}
-	f := func(r1, r2 x86asm.Reg) bool {
-		switch r1 {
-		case x86asm.EAX:
-			return r2 == x86asm.RAX
-		case x86asm.ECX:
-			return r2 == x86asm.RCX
-		case x86asm.EDX:
-			return r2 == x86asm.RDX
-		case x86asm.EBX:
-			return r2 == x86asm.RBX
-		case x86asm.ESI:
-			return r2 == x86asm.RSI
-		default:
-			return false
-		}
-	}
-	return f(r1, r2) || f(r2, r1)
 }

--- a/interpreter/luajit/offsets_test.go
+++ b/interpreter/luajit/offsets_test.go
@@ -211,14 +211,57 @@ func TestX86LuaClose(t *testing.T) {
 				0x48, 0x89, 0xb3, 0x58, 0x01, 0x00, 0x00, // movq    %rsi, 0x158(%rbx)
 			},
 		},
+		{
+			// The canonical form per lua_close's source uses `movq $0x0, OFS(reg)`
+			// directly instead of zeroing a register first.
+			name:          "immediate-zero-store",
+			glRefExpected: 0x10,
+			curLExpected:  0x170,
+			code: []byte{
+				0x48, 0x8b, 0x5f, 0x10, //                                     movq $0x10(%rdi), %rbx
+				0x48, 0xc7, 0x83, 0x70, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // movq $0x0, 0x170(%rbx)
+			},
+		},
+		{
+			// endbr64 prefix - the asm/amd interpreter skips it transparently
+			// so we no longer need an explicit SkipEndBranch call.
+			name:          "endbr64-prefix",
+			glRefExpected: 0x10,
+			curLExpected:  0x158,
+			code: []byte{
+				0xf3, 0x0f, 0x1e, 0xfa, //                                     endbr64
+				0x48, 0x8b, 0x5f, 0x10, //                                     movq 0x10(%rdi), %rbx
+				0x48, 0xc7, 0x83, 0x58, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // movq $0x0, 0x158(%rbx)
+			},
+		},
+		{
+			// Resilience case the old extractor would miss on two counts:
+			//   1. R8 was zeroed via `xor %r8d, %r8d`; sameReg() only
+			//      whitelisted EAX/ECX/EDX/EBX/ESI so R8/R8D would not match.
+			//   2. The glref load is *not* directly from %rdi - the compiler
+			//      first parked L in %rax, then loaded G via %rax. The old
+			//      code required a1.Base == x86asm.RDI on the load.
+			// Symbolic tracking handles both for free.
+			name:          "r8-zero-and-rdi-mov-chain",
+			glRefExpected: 0x10,
+			curLExpected:  0x158,
+			code: []byte{
+				0x45, 0x31, 0xc0, //                                     xorl %r8d, %r8d
+				0x48, 0x89, 0xf8, //                                     movq %rdi, %rax
+				0x48, 0x8b, 0x58, 0x10, //                               movq 0x10(%rax), %rbx
+				0x4c, 0x89, 0x83, 0x58, 0x01, 0x00, 0x00, //             movq %r8, 0x158(%rbx)
+			},
+		},
 	}
 
 	for _, test := range testdata {
-		x := x86Extractor{}
-		glref, curL, err := x.findOffsetsFromLuaClose(test.code)
-		require.NoError(t, err)
-		require.Equal(t, test.glRefExpected, glref)
-		require.Equal(t, test.curLExpected, curL)
+		t.Run(test.name, func(t *testing.T) {
+			x := x86Extractor{}
+			glref, curL, err := x.findOffsetsFromLuaClose(test.code)
+			require.NoError(t, err)
+			require.Equal(t, test.glRefExpected, glref)
+			require.Equal(t, test.curLExpected, curL)
+		})
 	}
 }
 

--- a/interpreter/luajit/offsets_test.go
+++ b/interpreter/luajit/offsets_test.go
@@ -265,6 +265,74 @@ func TestX86LuaClose(t *testing.T) {
 	}
 }
 
+func TestX86Checktrace(t *testing.T) {
+	testdata := []struct {
+		name     string
+		expected uint64
+		code     []byte
+	}{
+		{
+			// Canonical jit_checktrace per the disasm comment in
+			// extractor_x86.go: L (%rdi) is parked in %rbx, G is loaded as
+			// L->glref via 0x10(%rbx), then the J->traces load is at
+			// 0x430(%rdx).
+			name:     "canonical",
+			expected: 0x430,
+			code: []byte{
+				0x48, 0x89, 0xfb, //                         mov  %rdi, %rbx
+				0x48, 0x8b, 0x53, 0x10, //                   mov  0x10(%rbx), %rdx
+				0x48, 0x8b, 0x92, 0x30, 0x04, 0x00, 0x00, // mov  0x430(%rdx), %rdx
+			},
+		},
+		{
+			// SUB-shifted register: some builds apply a constant adjustment to
+			// G's register before the final load. Old extractor accumulated
+			// this manually; symbolic interpreter folds (-0xc + 0x43c) into
+			// 0x430 via Add canonicalization. Recently broke in the wild
+			// (#99ec409).
+			name:     "sub-adjusted",
+			expected: 0x430,
+			code: []byte{
+				0x48, 0x8b, 0x57, 0x10, //                   mov  0x10(%rdi), %rdx
+				0x48, 0x83, 0xea, 0x0c, //                   sub  $0xc, %rdx
+				0x48, 0x8b, 0x92, 0x3c, 0x04, 0x00, 0x00, // mov  0x43c(%rdx), %rdx
+			},
+		},
+		{
+			// ADD-shifted register: symmetric to the SUB case. (0xc + 0x424) = 0x430.
+			name:     "add-adjusted",
+			expected: 0x430,
+			code: []byte{
+				0x48, 0x8b, 0x57, 0x10, //                   mov  0x10(%rdi), %rdx
+				0x48, 0x83, 0xc2, 0x0c, //                   add  $0xc, %rdx
+				0x48, 0x8b, 0x92, 0x24, 0x04, 0x00, 0x00, // mov  0x424(%rdx), %rdx
+			},
+		},
+		{
+			// Resilience case: G is moved to an intermediate register before
+			// the final load. Old extractor required the load's base to be
+			// the same register that received the 0x10(L) load directly;
+			// symbolic tracking propagates the value through the chain.
+			name:     "mov-chain-through-intermediate-reg",
+			expected: 0x430,
+			code: []byte{
+				0x48, 0x8b, 0x57, 0x10, //                   mov  0x10(%rdi), %rdx
+				0x48, 0x89, 0xd6, //                         mov  %rdx, %rsi
+				0x48, 0x8b, 0x8e, 0x30, 0x04, 0x00, 0x00, // mov  0x430(%rsi), %rcx
+			},
+		},
+	}
+
+	for _, tc := range testdata {
+		t.Run(tc.name, func(t *testing.T) {
+			x := x86Extractor{}
+			got, err := x.findG2TracesOffsetFromChecktrace(tc.code)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
 // spot testing
 func TestFiles(t *testing.T) {
 	files, err := os.ReadDir("./testdata")

--- a/interpreter/luajit/offsets_test.go
+++ b/interpreter/luajit/offsets_test.go
@@ -333,6 +333,146 @@ func TestX86Checktrace(t *testing.T) {
 	}
 }
 
+func TestX86LjDispatchUpdateAddr(t *testing.T) {
+	testdata := []struct {
+		name     string
+		baseAddr uint64
+		expected uint64
+		code     []byte
+	}{
+		{
+			// Canonical: stash L in callee-saved %rbx, then load G into %rdi
+			// for the lj_dispatch_update call. CALL targets baseAddr+12+0xff4
+			// = 0x1000.
+			name:     "canonical-via-rbx",
+			baseAddr: 0,
+			expected: 0x1000,
+			code: []byte{
+				0x48, 0x89, 0xfb, //                      mov  %rdi, %rbx
+				0x48, 0x8b, 0x7b, 0x10, //                mov  0x10(%rbx), %rdi
+				0xe8, 0xf4, 0x0f, 0x00, 0x00, //          call 0x1000
+			},
+		},
+		{
+			// Resilience case: the compiler loads G straight into %rdi without
+			// first parking L in a separate register. The old extractor's
+			// Lreg-then-load pattern required the stash; symbolic tracking
+			// follows L's provenance through the self-overwrite of %rdi.
+			name:     "direct-rdi-self-overwrite",
+			baseAddr: 0,
+			expected: 0x1000,
+			code: []byte{
+				0x48, 0x8b, 0x7f, 0x10, //                mov  0x10(%rdi), %rdi
+				0xe8, 0xf7, 0x0f, 0x00, 0x00, //          call 0x1000
+			},
+		},
+		{
+			// Earlier calls in the prologue do not have G in %rdi and must be
+			// skipped over without consuming the result.
+			name:     "skip-prologue-call",
+			baseAddr: 0,
+			expected: 0x1000,
+			code: []byte{
+				0x48, 0x89, 0xfb, //                      mov  %rdi, %rbx
+				0xe8, 0xf8, 0x04, 0x00, 0x00, //          call 0x500 (not dispatch_update)
+				0x48, 0x8b, 0x7b, 0x10, //                mov  0x10(%rbx), %rdi
+				0xe8, 0xef, 0x0f, 0x00, 0x00, //          call 0x1000 (dispatch_update)
+			},
+		},
+	}
+
+	for _, tc := range testdata {
+		t.Run(tc.name, func(t *testing.T) {
+			x := x86Extractor{}
+			got, err := x.findLjDispatchUpdateAddr(tc.code, tc.baseAddr)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestX86RipRelativeLea2ndArgTo2ndCall(t *testing.T) {
+	// Two LEA-CALL pairs; both CALLs target 0x1000. After the 1st call's LEA
+	// RSI = 0x500; after the 2nd's RSI = 0xa00. The function should return
+	// 0xa00 (RSI's value at the 2nd matching CALL).
+	code := []byte{
+		0x48, 0x8d, 0x35, 0xf9, 0x04, 0x00, 0x00, // lea  0x4f9(%rip), %rsi  ; RSI = 0+7+0x4f9 = 0x500
+		0xe8, 0xf4, 0x0f, 0x00, 0x00, //             call 0x1000             ; target=0+12+0xff4
+		0x48, 0x8d, 0x35, 0xed, 0x09, 0x00, 0x00, // lea  0x9ed(%rip), %rsi  ; RSI = 0+19+0x9ed = 0xa00
+		0xe8, 0xe8, 0x0f, 0x00, 0x00, //             call 0x1000             ; target=0+24+0xfe8
+	}
+	x := x86Extractor{}
+	got, err := x.find2ndArgTo2ndPushClosureCall(code, 0, 0x1000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0xa00), got)
+}
+
+func TestX86Find4thArgToLibRegCall(t *testing.T) {
+	testdata := []struct {
+		name     string
+		expected int64
+		code     []byte
+	}{
+		{
+			// Canonical luaopen_jit_util: lea $rip-rel, %rcx; ...; call lj_lib_register.
+			// LEA at pos 4 (7 bytes), so RCX = 0 + 11 + 0xd21f5 = 0xd2200.
+			name:     "lea-rip-relative",
+			expected: 0xd2200,
+			code: []byte{
+				0x48, 0x83, 0xec, 0x08, //                   sub  $0x8, %rsp
+				0x48, 0x8d, 0x0d, 0xf5, 0x21, 0x0d, 0x00, // lea  0xd21f5(%rip), %rcx
+				0xe8, 0xf0, 0xff, 0x01, 0x00, //             call (target irrelevant)
+			},
+		},
+		{
+			// Some compilers materialize the 4th arg via `mov $imm, %ecx`.
+			name:     "mov-immediate",
+			expected: 0x1234,
+			code: []byte{
+				0xb9, 0x34, 0x12, 0x00, 0x00, //             mov  $0x1234, %ecx
+				0xe8, 0xfb, 0x1f, 0x00, 0x00, //             call (target irrelevant)
+			},
+		},
+	}
+
+	for _, tc := range testdata {
+		t.Run(tc.name, func(t *testing.T) {
+			x := x86Extractor{}
+			got, err := x.find4thArgToLibRegCall(tc.code, 0)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestX86Find3rdArgToLibPreregCall(t *testing.T) {
+	// Construct a minimal AABA call sequence (A=0x1000, B=0x2000) followed by
+	// 3 more CALLs, with `lea $rip-rel, %rdx` immediately before the 3rd.
+	// AABA section occupies bytes 0-19; the post-AABA interpreter section
+	// runs from byte 20 onward with CodeAddress=20:
+	//   pos 20-24: CALL (target irrelevant - 1st post-AABA)
+	//   pos 25-29: CALL                                (2nd)
+	//   pos 30-36: LEA  0x3fdb(%rip), %rdx  -> RDX = 20 + 17 + 0x3fdb = 0x4000
+	//   pos 37-41: CALL                                (3rd - read RDX here)
+	code := []byte{
+		// AABA: A, A, B, A (A=0x1000, B=0x2000), each call is 5 bytes
+		0xe8, 0xfb, 0x0f, 0x00, 0x00, //                 call 0x1000   (A, pos 0)
+		0xe8, 0xf6, 0x0f, 0x00, 0x00, //                 call 0x1000   (A, pos 5)
+		0xe8, 0xf1, 0x1f, 0x00, 0x00, //                 call 0x2000   (B, pos 10)
+		0xe8, 0xec, 0x0f, 0x00, 0x00, //                 call 0x1000   (A, pos 15) -> ip=20
+
+		// Post-AABA section interpreted with CodeAddress=20.
+		0xe8, 0x00, 0x00, 0x00, 0x00, //                 call (1st post-AABA, pos 20)
+		0xe8, 0x00, 0x00, 0x00, 0x00, //                 call (2nd post-AABA, pos 25)
+		0x48, 0x8d, 0x15, 0xdb, 0x3f, 0x00, 0x00, //     lea  0x3fdb(%rip), %rdx
+		0xe8, 0x00, 0x00, 0x00, 0x00, //                 call (3rd post-AABA, pos 37)
+	}
+	x := x86Extractor{}
+	got, err := x.find3rdArgToLibPreregCall(code, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x4000), got)
+}
+
 // spot testing
 func TestFiles(t *testing.T) {
 	files, err := os.ReadDir("./testdata")


### PR DESCRIPTION
Migrates the two simplest x86 LuaJIT extractors onto the `asm/amd` symbolic interpreter, replacing hand-rolled register tracking.

- **`findOffsetsFromLuaClose`** — G's provenance (`Mem8([L + glref])`) survives MOV chains and 32/64-bit aliasing, and zero-detection falls out of the symbolic state. Drops the `sameReg` whitelist hack.
- **`findG2TracesOffsetFromChecktrace`** — ADD/SUB deltas on the G register fold into the load's address expression, so the captured displacement is the true G→traces offset whether the load is `0x430(%g)` or `0x43c(%g)` after a `sub $0xc, %g`. Includes the new `SUB reg, imm` interpreter support this relies on.

New `TestX86LuaClose` / `TestX86Checktrace` cover each pattern; the MOV-chain and R8-zero cases fail on the pre-migration extractors.

## Test plan
- [x] `go test ./asm/... ./interpreter/luajit/`
- [x] `TestOffsets` against cached openresty amd64 libs

