### PR TITLE
luajit: migrate x86 arg-to-call extractors to asm/amd interpreter

### DIFF
--- a/interpreter/luajit/extractor_x86.go
+++ b/interpreter/luajit/extractor_x86.go
@@ -258,41 +258,39 @@ func (x *x86Extractor) findG2DispatchOffsetFromLjDispatchUpdate(b []byte) (uint6
 //
 //nolint:lll
 func (x *x86Extractor) findLjDispatchUpdateAddr(b []byte, addr uint64) (uint64, error) {
-	b, ip := xh.SkipEndBranch(b)
-	var Lreg x86asm.Reg
-	rdiHasG := false
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
-		if err != nil {
-			return 0, err
-		}
-		if i.Op == x86asm.MOV {
-			if a1, ok1 := i.Args[1].(x86asm.Reg); ok1 && a1 == x86asm.RDI {
-				if a0, ok0 := i.Args[0].(x86asm.Reg); ok0 {
-					Lreg = a0
-				}
-			}
-			if a0, ok := i.Args[0].(x86asm.Reg); ok && a0 == x86asm.RDI {
-				if a1, ok1 := i.Args[1].(x86asm.Mem); ok1 {
-					// Look for: movq   0x10(%rbx), %rdi
-					if a1.Base == Lreg && a1.Disp == 0x10 {
-						rdiHasG = true
-					}
-				}
-			}
-		}
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(addr)
+	// L is initial RDI (SysV first arg). lj_dispatch_update's first arg is G,
+	// reached via L->glref at offset 0x10. We don't care which register the
+	// compiler parks L in - symbolic tracking handles the chain.
+	L := it.Regs.GetX86(x86asm.RDI)
+	G := expression.Mem8(expression.Add(L, expression.Imm(0x10)))
 
-		if i.Op == x86asm.CALL && rdiHasG {
-			offset := int64(i.Args[0].(x86asm.Rel))
-			callAddr := int64(addr) + ip + offset + int64(i.Len)
-			// TODO: make sure callAddr is within .text bounds?
-			if callAddr < 0 {
-				return 0, errors.New("invalid call address")
+	for {
+		inst, err := it.Step()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
 			}
-			return uint64(callAddr), nil
+			return 0, fmt.Errorf("scanning function body: %w", err)
 		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+		if inst.Op != x86asm.CALL {
+			continue
+		}
+		if !it.Regs.GetX86(x86asm.RDI).Match(G) {
+			continue
+		}
+		rel, ok := inst.Args[0].(x86asm.Rel)
+		if !ok {
+			continue
+		}
+		// it.PC() is the offset past the CALL within the interpreter's bytes,
+		// which equals the offset in the caller's bytes since we started at 0.
+		callAddr := int64(addr) + int64(it.PC()) + int64(rel)
+		if callAddr < 0 {
+			return 0, errors.New("invalid call address")
+		}
+		return uint64(callAddr), nil
 	}
 	return 0, errors.New("lj_dispatch_update addr not found")
 }
@@ -403,37 +401,41 @@ func (x *x86Extractor) callExists(b []byte, baseAddr, targetCall int64) (bool, e
 //
 //nolint:lll
 func (x *x86Extractor) find2ndArgTo2ndPushClosureCall(b []byte, baseAddr, targetCall int64) (uint64, error) {
-	var leaRsi int64
-	calls := 2
-	b, ip := xh.SkipEndBranch(b)
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(uint64(baseAddr))
+	callsLeft := 2
+
+	for {
+		inst, err := it.Step()
 		if err != nil {
-			return 0, err
-		}
-		if i.Op == x86asm.LEA {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Mem)
-			if ok1 && ok2 {
-				if a0 == x86asm.RSI && a1.Base == x86asm.RIP {
-					leaRsi = calcRipRelativeAddr(a1, baseAddr, ip+int64(i.Len))
-				}
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			return 0, fmt.Errorf("scanning function body: %w", err)
 		}
-		if i.Op == x86asm.CALL {
-			a0, ok := i.Args[0].(x86asm.Rel)
-			if ok {
-				callAddr := baseAddr + ip + int64(i.Len) + int64(a0)
-				if callAddr == targetCall {
-					calls--
-					if calls == 0 {
-						return uint64(leaRsi), nil
-					}
-				}
-			}
+		if inst.Op != x86asm.CALL {
+			continue
 		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+		rel, ok := inst.Args[0].(x86asm.Rel)
+		if !ok {
+			continue
+		}
+		if baseAddr+int64(it.PC())+int64(rel) != targetCall {
+			continue
+		}
+		callsLeft--
+		if callsLeft > 0 {
+			continue
+		}
+		// Each LEA $disp(%rip), %rsi the interpreter has executed sets RSI to
+		// a concrete absolute address (CodeAddress + pc_after_lea + disp).
+		// Read whatever RSI currently holds; if the immediate-preceding LEA
+		// canonicalized to an Imm it will match.
+		rsiCap := expression.NewImmediateCapture("rsi")
+		if !it.Regs.GetX86(x86asm.RSI).Match(rsiCap) {
+			return 0, errors.New("RSI is not a concrete address at the 2nd matching call")
+		}
+		return rsiCap.CapturedValue(), nil
 	}
 	return 0, errors.New("failed to find rip relative lea instruction stored in rsi")
 }
@@ -489,8 +491,6 @@ func skipCallsAABA(b []byte, ip, baseAddr int64) ([]byte, int64, error) {
 // 6d973:	48 8d 35 1c a2 00 00 	lea    0xa21c(%rip),%rsi     # 77b96 <lj_lib_init_debug+0x236>
 // 6d97a:	e8 a1 28 ff ff       	call   60220 <lj_lib_prereg>
 func (x *x86Extractor) find3rdArgToLibPreregCall(b []byte, baseAddr int64) (uint64, error) {
-	var rdxAddr int64
-	calls := 3
 	b, ip := xh.SkipEndBranch(b)
 	// Skip the lua_push* call sequence (and all the preceding calls which varies depending on
 	// inlining).
@@ -509,40 +509,39 @@ func (x *x86Extractor) find3rdArgToLibPreregCall(b []byte, baseAddr int64) (uint
 	// libluajit-5.1.so[0x700dd] <+189>: movl   $0x12, %edx
 	// libluajit-5.1.so[0x700e2] <+194>: leaq   0x9b0a(%rip), %rsi
 	// libluajit-5.1.so[0x700e9] <+201>: callq  0x9af0         ; symbol stub for: lua_pushlstring
-	var err error
-	b, ip, err = skipCallsAABA(b, ip, baseAddr)
+	b, ip, err := skipCallsAABA(b, ip, baseAddr)
 	if err != nil {
 		return 0, err
 	}
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
+
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(uint64(baseAddr + ip))
+	callsLeft := 3
+
+	for {
+		inst, err := it.Step()
 		if err != nil {
-			return 0, err
-		}
-		// Some compilers will use MOV instead of LEA
-		if i.Op == x86asm.MOV {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			if ok1 && a0 == x86asm.EDX {
-				rdxAddr = int64(i.Args[1].(x86asm.Imm))
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			return 0, fmt.Errorf("scanning function body: %w", err)
 		}
-		if i.Op == x86asm.LEA {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Mem)
-			if ok1 && ok2 {
-				if a0 == x86asm.RDX && a1.Base == x86asm.RIP {
-					rdxAddr = calcRipRelativeAddr(a1, baseAddr, ip+int64(i.Len))
-				}
-			}
+		if inst.Op != x86asm.CALL {
+			continue
 		}
-		if i.Op == x86asm.CALL {
-			calls--
-			if calls == 0 {
-				return uint64(rdxAddr), nil
-			}
+		callsLeft--
+		if callsLeft > 0 {
+			continue
 		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+		// At the 3rd call after AABA, RDX should hold the luaopen_jit_util
+		// address - either via `lea $rip-rel, %rdx` (canonicalized to a
+		// concrete Imm by the interpreter) or `mov $imm, %edx` (some
+		// compilers).
+		rdxCap := expression.NewImmediateCapture("rdx")
+		if !it.Regs.GetX86(x86asm.RDX).Match(rdxCap) {
+			return 0, errors.New("RDX is not a concrete value at the 3rd post-AABA call")
+		}
+		return rdxCap.CapturedValue(), nil
 	}
 	return 0, errors.New("failed to find 3rd arg to lj_lib_prereg call")
 }
@@ -558,39 +557,20 @@ func (x *x86Extractor) find3rdArgToLibPreregCall(b []byte, baseAddr int64) (uint
 // bbbe:	48 83 c4 08          	add    $0x8,%rsp
 // bbc2:	c3                   	ret
 func (x *x86Extractor) find4thArgToLibRegCall(b []byte, baseAddr int64) (int64, error) {
-	var ip int64
-	b, ip = xh.SkipEndBranch(b)
-	for len(b) > 0 {
-		i, err := x86asm.Decode(b, 64)
-		if err != nil {
-			return 0, err
-		}
-		if i.Op == x86asm.LEA {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Mem)
-			if ok1 && ok2 {
-				// RCX is 4th arg
-				if a0 == x86asm.RCX && a1.Base == x86asm.RIP {
-					return calcRipRelativeAddr(a1, baseAddr, ip+int64(i.Len)), nil
-				}
-			}
-		}
-		if i.Op == x86asm.MOV {
-			a0, ok1 := i.Args[0].(x86asm.Reg)
-			a1, ok2 := i.Args[1].(x86asm.Imm)
-			if ok1 && ok2 && a0 == x86asm.ECX {
-				return int64(a1), nil
-			}
-		}
-		ip += int64(i.Len)
-		b = b[i.Len:]
+	it := amd.NewInterpreterWithCode(b)
+	it.CodeAddress = expression.Imm(uint64(baseAddr))
+	// luaopen_jit_util's body is: set up call args (RCX via either
+	// `lea $rip-rel, %rcx` or `mov $imm, %ecx`), then call lj_lib_register.
+	// Step until that CALL, then read RCX symbolically.
+	_, err := it.LoopWithBreak(func(op x86asm.Inst) bool {
+		return op.Op == x86asm.CALL
+	})
+	if err != nil && err != io.EOF {
+		return 0, err
 	}
-	return 0, errors.New("failed to find 4th arg to lj_reg call")
-}
-
-func calcRipRelativeAddr(a1 x86asm.Mem, baseAddr, ip int64) int64 {
-	// Disp is an int64 but its not set properly and negative numbers
-	// are 32 bit.  TODO: This is a bug that should be created/looked up.
-	disp := int32(a1.Disp)
-	return baseAddr + ip + int64(disp)
+	rcxCap := expression.NewImmediateCapture("rcx")
+	if !it.Regs.GetX86(x86asm.RCX).Match(rcxCap) {
+		return 0, errors.New("failed to find 4th arg to lj_reg call")
+	}
+	return int64(rcxCap.CapturedValue()), nil
 }

--- a/interpreter/luajit/offsets_test.go
+++ b/interpreter/luajit/offsets_test.go
@@ -333,6 +333,146 @@ func TestX86Checktrace(t *testing.T) {
 	}
 }
 
+func TestX86LjDispatchUpdateAddr(t *testing.T) {
+	testdata := []struct {
+		name     string
+		baseAddr uint64
+		expected uint64
+		code     []byte
+	}{
+		{
+			// Canonical: stash L in callee-saved %rbx, then load G into %rdi
+			// for the lj_dispatch_update call. CALL targets baseAddr+12+0xff4
+			// = 0x1000.
+			name:     "canonical-via-rbx",
+			baseAddr: 0,
+			expected: 0x1000,
+			code: []byte{
+				0x48, 0x89, 0xfb, //                      mov  %rdi, %rbx
+				0x48, 0x8b, 0x7b, 0x10, //                mov  0x10(%rbx), %rdi
+				0xe8, 0xf4, 0x0f, 0x00, 0x00, //          call 0x1000
+			},
+		},
+		{
+			// Resilience case: the compiler loads G straight into %rdi without
+			// first parking L in a separate register. The old extractor's
+			// Lreg-then-load pattern required the stash; symbolic tracking
+			// follows L's provenance through the self-overwrite of %rdi.
+			name:     "direct-rdi-self-overwrite",
+			baseAddr: 0,
+			expected: 0x1000,
+			code: []byte{
+				0x48, 0x8b, 0x7f, 0x10, //                mov  0x10(%rdi), %rdi
+				0xe8, 0xf7, 0x0f, 0x00, 0x00, //          call 0x1000
+			},
+		},
+		{
+			// Earlier calls in the prologue do not have G in %rdi and must be
+			// skipped over without consuming the result.
+			name:     "skip-prologue-call",
+			baseAddr: 0,
+			expected: 0x1000,
+			code: []byte{
+				0x48, 0x89, 0xfb, //                      mov  %rdi, %rbx
+				0xe8, 0xf8, 0x04, 0x00, 0x00, //          call 0x500 (not dispatch_update)
+				0x48, 0x8b, 0x7b, 0x10, //                mov  0x10(%rbx), %rdi
+				0xe8, 0xef, 0x0f, 0x00, 0x00, //          call 0x1000 (dispatch_update)
+			},
+		},
+	}
+
+	for _, tc := range testdata {
+		t.Run(tc.name, func(t *testing.T) {
+			x := x86Extractor{}
+			got, err := x.findLjDispatchUpdateAddr(tc.code, tc.baseAddr)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestX86RipRelativeLea2ndArgTo2ndCall(t *testing.T) {
+	// Two LEA-CALL pairs; both CALLs target 0x1000. After the 1st call's LEA
+	// RSI = 0x500; after the 2nd's RSI = 0xa00. The function should return
+	// 0xa00 (RSI's value at the 2nd matching CALL).
+	code := []byte{
+		0x48, 0x8d, 0x35, 0xf9, 0x04, 0x00, 0x00, // lea  0x4f9(%rip), %rsi  ; RSI = 0+7+0x4f9 = 0x500
+		0xe8, 0xf4, 0x0f, 0x00, 0x00, //             call 0x1000             ; target=0+12+0xff4
+		0x48, 0x8d, 0x35, 0xed, 0x09, 0x00, 0x00, // lea  0x9ed(%rip), %rsi  ; RSI = 0+19+0x9ed = 0xa00
+		0xe8, 0xe8, 0x0f, 0x00, 0x00, //             call 0x1000             ; target=0+24+0xfe8
+	}
+	x := x86Extractor{}
+	got, err := x.find2ndArgTo2ndPushClosureCall(code, 0, 0x1000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0xa00), got)
+}
+
+func TestX86Find4thArgToLibRegCall(t *testing.T) {
+	testdata := []struct {
+		name     string
+		expected int64
+		code     []byte
+	}{
+		{
+			// Canonical luaopen_jit_util: lea $rip-rel, %rcx; ...; call lj_lib_register.
+			// LEA at pos 4 (7 bytes), so RCX = 0 + 11 + 0xd21f5 = 0xd2200.
+			name:     "lea-rip-relative",
+			expected: 0xd2200,
+			code: []byte{
+				0x48, 0x83, 0xec, 0x08, //                   sub  $0x8, %rsp
+				0x48, 0x8d, 0x0d, 0xf5, 0x21, 0x0d, 0x00, // lea  0xd21f5(%rip), %rcx
+				0xe8, 0xf0, 0xff, 0x01, 0x00, //             call (target irrelevant)
+			},
+		},
+		{
+			// Some compilers materialize the 4th arg via `mov $imm, %ecx`.
+			name:     "mov-immediate",
+			expected: 0x1234,
+			code: []byte{
+				0xb9, 0x34, 0x12, 0x00, 0x00, //             mov  $0x1234, %ecx
+				0xe8, 0xfb, 0x1f, 0x00, 0x00, //             call (target irrelevant)
+			},
+		},
+	}
+
+	for _, tc := range testdata {
+		t.Run(tc.name, func(t *testing.T) {
+			x := x86Extractor{}
+			got, err := x.find4thArgToLibRegCall(tc.code, 0)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestX86Find3rdArgToLibPreregCall(t *testing.T) {
+	// Construct a minimal AABA call sequence (A=0x1000, B=0x2000) followed by
+	// 3 more CALLs, with `lea $rip-rel, %rdx` immediately before the 3rd.
+	// AABA section occupies bytes 0-19; the post-AABA interpreter section
+	// runs from byte 20 onward with CodeAddress=20:
+	//   pos 20-24: CALL (target irrelevant - 1st post-AABA)
+	//   pos 25-29: CALL                                (2nd)
+	//   pos 30-36: LEA  0x3fdb(%rip), %rdx  -> RDX = 20 + 17 + 0x3fdb = 0x4000
+	//   pos 37-41: CALL                                (3rd - read RDX here)
+	code := []byte{
+		// AABA: A, A, B, A (A=0x1000, B=0x2000), each call is 5 bytes
+		0xe8, 0xfb, 0x0f, 0x00, 0x00, //                 call 0x1000   (A, pos 0)
+		0xe8, 0xf6, 0x0f, 0x00, 0x00, //                 call 0x1000   (A, pos 5)
+		0xe8, 0xf1, 0x1f, 0x00, 0x00, //                 call 0x2000   (B, pos 10)
+		0xe8, 0xec, 0x0f, 0x00, 0x00, //                 call 0x1000   (A, pos 15) -> ip=20
+
+		// Post-AABA section interpreted with CodeAddress=20.
+		0xe8, 0x00, 0x00, 0x00, 0x00, //                 call (1st post-AABA, pos 20)
+		0xe8, 0x00, 0x00, 0x00, 0x00, //                 call (2nd post-AABA, pos 25)
+		0x48, 0x8d, 0x15, 0xdb, 0x3f, 0x00, 0x00, //     lea  0x3fdb(%rip), %rdx
+		0xe8, 0x00, 0x00, 0x00, 0x00, //                 call (3rd post-AABA, pos 37)
+	}
+	x := x86Extractor{}
+	got, err := x.find3rdArgToLibPreregCall(code, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0x4000), got)
+}
+
 // spot testing
 func TestFiles(t *testing.T) {
 	files, err := os.ReadDir("./testdata")


### PR DESCRIPTION
Stacked on #314. Migrates the remaining four x86 LuaJIT extractors onto the `asm/amd` interpreter: `findLjDispatchUpdateAddr`, `find2ndArgTo2ndPushClosureCall`, `find3rdArgToLibPreregCall`, `find4thArgToLibRegCall`.

Each drives the interpreter through the bytes, counts CALLs, and reads the relevant arg register (RDI/RSI/RDX/RCX) symbolically. The interpreter's RIP-relative handling yields concrete absolute addresses, so the local `calcRipRelativeAddr` helper goes away — this is what depends on the disp sign-extension fix in #314.

`findLjDispatchUpdateAddr` also no longer requires L to be parked in a separate register before the G load; `TestX86LjDispatchUpdateAddr/direct-rdi-self-overwrite` fails on the pre-migration extractor.


## Test plan
- [x] `go test ./interpreter/luajit/` incl. `TestOffsets` against cached openresty amd64 libs
- [x] `direct-rdi-self-overwrite` confirmed failing pre-migration
