### PR TITLE
gpu: stat libparcagpucupti.so via /proc/<pid>/root and surface attach errors

### DIFF
--- a/interpreter/gpu/cuda.go
+++ b/interpreter/gpu/cuda.go
@@ -430,15 +430,18 @@ func (d *data) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, _ libpf.Addre
 		}
 	}
 
-	// Stat the path to get the current inode. Uprobe attachments are
-	// inode-based, so we need a separate attachment per inode.
-	st, err := os.Stat(d.path)
+	// Stat the path via /proc/<pid>/root so this works when parca-agent runs
+	// in a container that doesn't share the target's mount namespace. The
+	// subsequent AttachUSDTProbes call already opens the file via the same
+	// /proc/<pid>/root prefix.
+	containerPath := "/proc/" + strconv.Itoa(int(pid)) + "/root/" + d.path
+	st, err := os.Stat(containerPath)
 	if err != nil {
-		return nil, fmt.Errorf("[cuda] stat %s: %w", d.path, err)
+		return nil, fmt.Errorf("[cuda] stat %s: %w", containerPath, err)
 	}
 	sys, ok := st.Sys().(*syscall.Stat_t)
 	if !ok || sys == nil {
-		return nil, fmt.Errorf("[cuda] failed to get stat_t for %s", d.path)
+		return nil, fmt.Errorf("[cuda] failed to get stat_t for %s", containerPath)
 	}
 	key := util.OnDiskFileIdentifier{DeviceID: uint64(sys.Dev), InodeNum: uint64(sys.Ino)}
 

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -366,7 +366,10 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapp
 	pm.assignLibcInfo(pr.PID(), ei.LibcInfo)
 	if ei.Data != nil {
 		bias := libpf.Address(m.Vaddr - elfSpaceVA)
-		pm.handleNewInterpreter(pr, bias, m.GetOnDiskFileIdentifier(), ei.Data)
+		if err := pm.handleNewInterpreter(pr, bias, m.GetOnDiskFileIdentifier(), ei.Data); err != nil {
+			log.Errorf("Failed to handle new interpreter for PID %d file %v: %v",
+				pr.PID(), m.Path, err)
+		}
 	}
 	pm.mu.Unlock()
 


### PR DESCRIPTION
## Summary
- Make the inode-tracking `os.Stat` in `gpu.(*data).Attach` namespace-aware by prefixing with `/proc/<pid>/root`, matching what `AttachUSDTProbes` does right after. Without this, parca-agent running in a container (e.g. the prebuilt `ghcr.io/parca-dev/parca-agent` image) fails to attach CUDA USDT probes because the host path doesn't exist inside the container's mount namespace — `Attach` returns early and no GPU/PC samples flow.
- Log the error returned by `handleNewInterpreter` in `newFrameMapping`. Previously it was discarded, which is why the cuda stat failure left no trace in the logs.

## Background
Reproduced by running the agent container with `--privileged --pid host --network host` (and host paths *not* mounted) against a CUDA workload that has `CUDA_INJECTION64_PATH=$HOME/.../libparcagpucupti.so` set. Agent log showed `Found parcagpu USDT probes …` (loader ran via `/proc/<pid>/map_files/<addr>`) but never `Attached N individual probes …`. Bisected to the `os.Stat(d.path)` added in 99905e20.

The lib path mapped by the target process (`/home/tpr/src/.../libparcagpucupti.so`) doesn't resolve from inside the distroless agent container. Both `link.OpenExecutable` in `AttachUSDTProbes` (ebpf.go:239) and `systemProcess.OpenELF` fall back to `/proc/<pid>/root/<path>` for this reason; the new `Stat` was the odd one out.

## Test plan
- [ ] Built `./interpreter/gpu` and `./processmanager` — clean.
- [ ] Repro with patched agent: `Attached 7 individual probes to /home/.../libparcagpucupti.so in PID …` appears within seconds of starting a CUDA workload, `parca_reporter_samples_total{type="gpu"}` and `{type="gpu_pc"}` start incrementing.
- [ ] No `/home`-on-host volume mount needed in the agent container.
- [ ] Negative case: deliberately point a workload at a missing lib path — secondary fix now produces `Failed to handle new interpreter for PID … : [cuda] stat /proc/<pid>/root/…: no such file or directory` in the agent log.