### PR TITLE
upstream merge: #1347 CI: fix collector test

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           COLLECTOR_PATH=/tmp/opentelemetry-collector ./support/local-collector.sh
           go mod tidy
+          go mod tidy -modfile=internal/tools/go.mod
       - name: Tests
         run: make test-junit
       - name: Generate Issue

--- a/support/local-collector.sh
+++ b/support/local-collector.sh
@@ -16,4 +16,6 @@ go list -m -u all | grep 'go\.opentelemetry\.io/collector' | while read -r line;
   LOCAL_PATH="$COLLECTOR_PATH/$REL_PATH"
   echo "Replacing $MODULE => $LOCAL_PATH"
   go mod edit -replace="$MODULE=$LOCAL_PATH"
+  # Also add replace directive to internal/tools/go.mod
+  go mod edit -modfile=internal/tools/go.mod -replace="$MODULE=$LOCAL_PATH"
 done


### PR DESCRIPTION
Single merge commit absorbing upstream PR #1347 "CI: fix collector test" (`395cc528`). Adds `go mod tidy -modfile=internal/tools/go.mod` to the Collector Tests workflow's "Setup replace statement" step so the tools module gets tidied alongside the main module.

Conflict was textual: parca's workflow has an `Install dependencies` step at the same insertion point. Resolved by keeping both — upstream's `go mod tidy -modfile=…` appended to the prior `run:` block, then parca's `Install dependencies` step preserved.

Produced by `upstream-merge.sh --leave-conflicted` with manual resolution of the single conflict.
