### PR TITLE
gpu: key cubin PC sample frames by per-function FileID

### DIFF
--- a/interpreter/gpu/cubin.go
+++ b/interpreter/gpu/cubin.go
@@ -92,6 +92,27 @@ func HandleCubinEvent(ev *CuptiCubinEvent, rep reporter.ExecutableReporter) {
 		Process: NewCubinProcess(ev.Pid, data),
 		IsElf:   true,
 	})
+
+	// Register a metadata-only executable for each kernel under its
+	// per-function FileID. PC sample frames are keyed by funcFileID (see
+	// pcsampling.go); without these entries the reporter can't resolve the
+	// frame's executable and emits a null build ID, so the per-function
+	// debuginfo the backend wrote (optimizer's PerFunctionCubinPCs fan-out)
+	// would never be looked up. IsElf=false records metadata without
+	// triggering a second upload of the cubin bytes.
+	for _, ts := range texts {
+		fnName := strings.TrimPrefix(ts.Name, ".text.")
+		if fnName == ts.Name || fnName == "" {
+			continue // section without a ".text.<mangled>" name
+		}
+		rep.ReportExecutable(&reporter.ExecutableMetadata{
+			MappingFile: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+				FileID:   funcFileID(ev.CubinCRC, fileID, fnName),
+				FileName: libpf.Intern(fmt.Sprintf("%s:%s", cubinName, fnName)),
+			}),
+			IsElf: false,
+		})
+	}
 }
 
 // ReadCubinFromProcess reads cubin bytes from a process's memory via /proc/pid/mem.

--- a/interpreter/gpu/funcfileid_test.go
+++ b/interpreter/gpu/funcfileid_test.go
@@ -1,0 +1,69 @@
+package gpu
+
+import (
+	"hash/fnv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+)
+
+// TestFuncFileIDDisambiguatesKernels verifies the agent-side half of the
+// per-function-FileID fix: two kernels in the SAME cubin must get distinct
+// FileIDs so their (FileID, 0-based-offset) sample frames don't alias.
+func TestFuncFileIDDisambiguatesKernels(t *testing.T) {
+	const crc = uint64(0xdeadbeefcafef00d)
+	cubinID := libpf.NewFileID(crc, 0)
+
+	a := funcFileID(crc, cubinID, "_Z12shmem_bouncePfiy")
+	b := funcFileID(crc, cubinID, "_Z10hash_churnPjiy")
+
+	// Different kernels in the same cubin -> different FileIDs.
+	assert.False(t, a.Equal(b), "two kernels collided onto one FileID")
+
+	// Same kernel -> same FileID (stable, so agent and backend agree).
+	assert.True(t, a.Equal(funcFileID(crc, cubinID, "_Z12shmem_bouncePfiy")))
+
+	// High word stays the cubin CRC so the backend can recover it and
+	// recompute the same per-function FileIDs from the cubin symbol table.
+	assert.Equal(t, crc, a.Hi())
+	assert.Equal(t, crc, b.Hi())
+
+	// Low word is exactly FNV-1a(name) — the contract the backend mirrors.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("_Z12shmem_bouncePfiy"))
+	assert.Equal(t, h.Sum64(), a.Lo())
+}
+
+// TestFuncFileIDMatchesBackendBuildID locks the cross-repo contract: the build
+// ID string the agent stamps on a cubin PC sample frame (fid.StringNoQuotes())
+// must byte-for-byte equal the per-function key the polarsignals optimizer
+// writes artifacts under (encodeFileID(cubinCRC, fnv1a64(name)) in
+// pkg/debuginfo/optimizer/cubin_index.go). These literals are the exact
+// outputs asserted by that package's TestCubinPerFunctionOptimize for
+// cubinCRC=0xabcddcba12344321 — if either side's hashing/encoding drifts, one
+// of the two tests breaks.
+func TestFuncFileIDMatchesBackendBuildID(t *testing.T) {
+	const cubinCRC = uint64(0xabcddcba12344321)
+	cubinID := libpf.NewFileID(cubinCRC, 0)
+
+	want := map[string]string{
+		"_Z12shmem_bouncePfiy": "abcddcba123443212868dcb2f58897ba",
+		"_Z10hash_churnPjiy":   "abcddcba12344321d886a737b53b5e78",
+		"_Z10trig_stormPfiy":   "abcddcba12344321f071fa7c1a632ded",
+	}
+	for name, expected := range want {
+		assert.Equal(t, expected, funcFileID(cubinCRC, cubinID, name).StringNoQuotes(),
+			"build ID for kernel %s drifted from the backend optimizer", name)
+	}
+}
+
+// TestFuncFileIDEmptyNameFallsBack covers the missing-name case: with no kernel
+// name we must not key on a hash of "" — we fall back to the per-cubin FileID.
+func TestFuncFileIDEmptyNameFallsBack(t *testing.T) {
+	const crc = uint64(0x1234)
+	cubinID := libpf.NewFileID(crc, 0)
+	require.True(t, funcFileID(crc, cubinID, "").Equal(cubinID))
+}

--- a/interpreter/gpu/pcsampling.go
+++ b/interpreter/gpu/pcsampling.go
@@ -2,6 +2,7 @@ package gpu // import "go.opentelemetry.io/ebpf-profiler/interpreter/gpu"
 
 import (
 	"fmt"
+	"hash/fnv"
 	"time"
 	"unique"
 
@@ -58,10 +59,18 @@ func HandlePCSample(ev *CuptiPCSampleEvent, rep reporter.TraceReporter) {
 		ev.Data.StallReasonCount, cpuTrace != nil)
 
 	// Build cubin file mapping for the offset frame.
-	cubinName := fmt.Sprintf("cubin-%016x", cubinInfo.CRC)
+	//
+	// The frame is keyed by a PER-FUNCTION FileID, not the per-cubin FileID:
+	// CUPTI reports pcOffset relative to the start of the kernel, and ptxas
+	// lays every kernel 0-based, so within one cubin offset 0x10 exists in
+	// every kernel. Keying on (cubinFileID, offset) alone would alias them.
+	// funcFileID folds the kernel name into the key so each kernel resolves to
+	// its own debuginfo (the backend partitions the cubin the same way via
+	// PerFunctionCubinPCs). The offset itself stays 0-based — unchanged.
+	cubinName := fmt.Sprintf("cubin-%016x:%s", cubinInfo.CRC, kernelName)
 	cubinMapping := libpf.NewFrameMapping(libpf.FrameMappingData{
 		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
-			FileID:   cubinInfo.FileID,
+			FileID:   funcFileID(cubinInfo.CRC, cubinInfo.FileID, kernelName),
 			FileName: libpf.Intern(cubinName),
 		}),
 	})
@@ -88,6 +97,25 @@ func HandlePCSample(ev *CuptiPCSampleEvent, rep reporter.TraceReporter) {
 				kernelName, ev.Data.PCOffset, mnemonic, stallName, sr.Index, sr.Samples)
 		}
 	}
+}
+
+// funcFileID derives the per-function FileID for a GPU PC sample frame.
+//
+// The high word carries the cubin CRC (so the backend can recover which cubin
+// this is) and the low word is a stable FNV-1a hash of the mangled kernel name,
+// which the backend reproduces from the cubin's symbol table when it partitions
+// the cubin in PerFunctionCubinPCs. Keep this hashing in sync with the backend.
+//
+// When the kernel name is unavailable we fall back to the per-cubin FileID
+// (low word 0) so symbolization degrades to the old behavior rather than
+// keying on a hash of the empty string.
+func funcFileID(cubinCRC uint64, cubinFileID libpf.FileID, functionName string) libpf.FileID {
+	if functionName == "" {
+		return cubinFileID
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(functionName))
+	return libpf.NewFileID(cubinCRC, h.Sum64())
 }
 
 // buildGpuPCTrace constructs a trace with GPU PC sampling frames, optionally


### PR DESCRIPTION
## Problem

CUPTI reports a cubin PC sample as a function-relative \`pcOffset\`, and ptxas lays every kernel 0-based (each \`.text.<kernel>\` at \`sh_addr=0\`, symbol \`Value=0\`). So within one cubin, offset \`0x10\` exists in every kernel. Keying a sample frame by \`(cubinFileID, offset)\` alone aliased the kernels — multi-kernel cubins were mis-symbolized, only one kernel surviving.

## Change

Stamp each cubin PC-sample frame with a **per-function FileID** = \`NewFileID(cubinCRC, fnv1a64(functionName))\`, so each kernel resolves to its own debuginfo. The offset itself stays 0-based (it already matches the cubin's 0-based \`.debug_line\`).

Also register a **metadata-only executable per kernel** at cubin-load time (derived from the \`.text.<mangled>\` sections) so the reporter can resolve the frame's executable and emit the per-function build ID — otherwise the frame's FileID isn't in the executables cache and the reporter emits a null mapping build ID.

## Backend pairing

The polarsignals backend writes one debuginfo artifact per kernel under the **same** build ID (cubinCRC recovered from the cubin's build ID, kernel name from its symbol table, identical FNV-1a + FileID-hex encoding). The contract is pinned by \`funcfileid_test.go\` here and the backend's \`TestCubinPerFunction*\` sharing the same literal build IDs — drift on either side breaks a test.

**Deploy order:** land/deploy the backend change first so the per-function frames have artifacts to resolve against; until then those frames fall back gracefully (unresolved), and old/merged behavior is unaffected.

## Tests

- \`TestFuncFileIDDisambiguatesKernels\` — distinct kernels in one cubin get distinct, stable FileIDs.
- \`TestFuncFileIDMatchesBackendBuildID\` — the emitted build-ID strings byte-match the backend optimizer's per-function keys.
- \`TestFuncFileIDEmptyNameFallsBack\` — missing kernel name falls back to the per-cubin FileID rather than hashing "".