### PR TITLE
coredump: add GCS fallback for reads and -gcs upload flag

### DIFF
--- a/.github/workflows/collector-tests.yml
+++ b/.github/workflows/collector-tests.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  COREDUMP_GCS_BUCKET: parca-coredump-artifacts
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Let coredump tests fall back to the public GCS bucket for artifacts that
+# haven't been uploaded to the primary storage yet (e.g. tests added on a fork
+# branch). The fallback read is anonymous, so no credentials are required.
+env:
+  COREDUMP_GCS_BUCKET: parca-coredump-artifacts
+
 jobs:
   legal:
     name: Check licenses of dependencies

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/smithy-go v1.24.2
 	github.com/cilium/ebpf v0.21.0
 	github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb
 	github.com/elastic/go-freelru v0.16.0
@@ -76,7 +77,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/tools/coredump/README.md
+++ b/tools/coredump/README.md
@@ -296,3 +296,39 @@ add references to this map manually to this package. This is because we do not
 currently support adding maps in an  automated fashion. The best way to do this
 is to look through existing code in this package and to see where existing code 
 refers to particular BPF maps.
+
+## Parca extension: fallback GCS bucket
+
+Currently, we have a GCS bucket called `parca-coredump-artifacts` that we can fall back to
+if artifacts are not available in the main storage.
+
+The purpose of this is to allow us to create coredump tests in our fork that haven't yet landed upstream.
+
+To use it, ensure that the environment setting `COREDUMP_GCS_BUCKET=parca-coredump-artifacts` is applied
+when running tests.
+
+We also have a `-gcs` flag to `coredump upload` for the same purpose. To use it, Parca maintainers
+should download `parca-coredump-artifacts-uploader` from our Bitbucket, save it as key.json, and execute the following commands to create
+an HMAC key:
+
+```bash
+# Create an HMAC key for the service account.
+gcloud auth activate-service-account --key-file=key.json
+gcloud storage hmac create "$(jq -r .client_email key.json)"
+```
+
+This prints an `accessId` and `secret`. (Note: these keys are long-running and only 5 are allowed per service account,
+so don't create a new one every time you use it).
+
+Once you have an accessId and a secret, you can upload coredumps like so:
+
+```bash
+export AWS_ACCESS_KEY_ID=<accessId>
+export AWS_SECRET_ACCESS_KEY=<secret>
+export COREDUMP_GCS_BUCKET=parca-coredump-artifacts
+./coredump upload -gcs -all
+```
+
+(If we ever run into the 5 key limit, we will have to delete some old ones with `gcloud storage hmac list`,
+followed by `gcloud storage hmac update <accessId> --deactivate` and
+`gcloud storage hmac delete <accessId>`.)

--- a/tools/coredump/cloudstore/cloudstore.go
+++ b/tools/coredump/cloudstore/cloudstore.go
@@ -7,6 +7,7 @@ package cloudstore // import "go.opentelemetry.io/ebpf-profiler/tools/coredump/c
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -29,21 +30,29 @@ const modulePublicReadURL = "sm-wftyyzHJkBghWeexmK1o5ArimNwZC-5eBej5Lx4e46sLVHtO
 // moduleStoreS3Bucket defines the S3 bucket used for the module store.
 const moduleStoreS3Bucket = "ebpf-profiling-coredumps"
 
-// gcsBucket defines the public GCS bucket used as an alternative module store.
-const gcsBucket = "parca-coredump-artifacts"
+// GCSBucketEnvVar names the environment variable that selects the GCS bucket
+// used as an alternative module store. When it is unset, GCS support (both the
+// read fallback and the `upload -gcs` target) is disabled.
+const GCSBucketEnvVar = "COREDUMP_GCS_BUCKET"
 
 // gcsEndpoint is the GCS S3-compatible XML API endpoint.
 const gcsEndpoint = "https://storage.googleapis.com"
 
-// GCSBucket returns the name of the public GCS module store bucket.
+// GCSBucket returns the GCS module store bucket configured via the
+// COREDUMP_GCS_BUCKET environment variable, or an empty string if it is unset.
 func GCSBucket() string {
-	return gcsBucket
+	return os.Getenv(GCSBucketEnvVar)
 }
 
 // GCSPublicReadURL returns the base URL used to anonymously read objects from
-// the public GCS module store bucket.
+// the configured public GCS module store bucket, or an empty string if no
+// bucket is configured.
 func GCSPublicReadURL() string {
-	return fmt.Sprintf("%s/%s/", gcsEndpoint, gcsBucket)
+	bucket := GCSBucket()
+	if bucket == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/", gcsEndpoint, bucket)
 }
 
 // GCSClient returns an S3 client configured to talk to GCS via its

--- a/tools/coredump/cloudstore/cloudstore.go
+++ b/tools/coredump/cloudstore/cloudstore.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 // moduleStoreRegion defines the S3 bucket OCI region.
@@ -26,6 +28,71 @@ const modulePublicReadURL = "sm-wftyyzHJkBghWeexmK1o5ArimNwZC-5eBej5Lx4e46sLVHtO
 
 // moduleStoreS3Bucket defines the S3 bucket used for the module store.
 const moduleStoreS3Bucket = "ebpf-profiling-coredumps"
+
+// gcsBucket defines the public GCS bucket used as an alternative module store.
+const gcsBucket = "parca-coredump-artifacts"
+
+// gcsEndpoint is the GCS S3-compatible XML API endpoint.
+const gcsEndpoint = "https://storage.googleapis.com"
+
+// GCSBucket returns the name of the public GCS module store bucket.
+func GCSBucket() string {
+	return gcsBucket
+}
+
+// GCSPublicReadURL returns the base URL used to anonymously read objects from
+// the public GCS module store bucket.
+func GCSPublicReadURL() string {
+	return fmt.Sprintf("%s/%s/", gcsEndpoint, gcsBucket)
+}
+
+// GCSClient returns an S3 client configured to talk to GCS via its
+// S3-compatible XML API. Credentials are loaded from the default AWS
+// credential chain (e.g. AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY set to a
+// GCS HMAC key pair).
+func GCSClient() (*s3.Client, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.Region = "auto"
+		o.BaseEndpoint = aws.String(gcsEndpoint)
+		o.UsePathStyle = true
+		// GCS's S3-compatible XML API is incompatible with two aws-sdk-go-v2
+		// defaults, both of which manifest as SignatureDoesNotMatch:
+		//
+		//  1. Since service/s3 v1.73.0 the SDK computes CRC32 checksums by
+		//     default and signs the resulting x-amz-checksum-* headers on
+		//     uploads. GCS does not expect them. Reverting to "when required"
+		//     restores the pre-v1.73.0, GCS-compatible behavior.
+		//     See https://github.com/longhorn/longhorn/issues/12676.
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+		//  2. The SDK adds and SigV4-signs an "Accept-Encoding: identity"
+		//     header, but GCS rewrites Accept-Encoding server-side before it
+		//     recomputes the signature, so the signatures no longer match.
+		//     (The SDK also signs amz-sdk-invocation-id / amz-sdk-request, but
+		//     GCS passes those through unchanged, so they don't need removing.)
+		//     There is no client option to exclude a header from signing, so
+		//     drop Accept-Encoding from every request just before signing, as in
+		//     https://github.com/aws/aws-sdk-go-v2/issues/1816#issuecomment-1927281540.
+		o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+			return stack.Finalize.Insert(
+				middleware.FinalizeMiddlewareFunc("StripAcceptEncodingForGCS",
+					func(ctx context.Context, in middleware.FinalizeInput,
+						next middleware.FinalizeHandler) (middleware.FinalizeOutput,
+						middleware.Metadata, error) {
+						if req, ok := in.Request.(*smithyhttp.Request); ok {
+							req.Header.Del("Accept-Encoding")
+						}
+						return next.HandleFinalize(ctx, in)
+					}),
+				"Signing", middleware.Before)
+		})
+	}), nil
+}
 
 func PublicReadURL() string {
 	return fmt.Sprintf("https://%s.objectstorage.%s.oci.customer-oci.com/p/%s/b/%s/o/",

--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -42,6 +42,9 @@ const (
 	s3ResultsPerPage = 1000
 	// s3MaxPages defines the maximum number of pages to ever retrieve when listing objects.
 	s3MaxPages = 16
+	// gcsFallbackURL is the public read URL of the GCS bucket used as a fallback
+	// source for artifacts that are not available from the primary remote storage.
+	gcsFallbackURL = "https://storage.googleapis.com/parca-coredump-artifacts/"
 	// zstpakChunkSize determines the chunk size to use when compressing files.
 	zstpakChunkSize = 64 * 1024
 )
@@ -471,31 +474,44 @@ func (store *Store) ensurePresentLocally(id ID) (string, error) {
 	}
 
 	moduleKey := makeS3Key(id)
-	resp, err := http.Get(store.publicReadURL + moduleKey)
+	err = store.downloadTo(store.publicReadURL+moduleKey, localPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to request file: %w", err)
+		// Fall back to the public GCS bucket before giving up.
+		log.Debugf("failed to fetch %s from primary storage (%v), trying GCS fallback",
+			id.String(), err)
+		fallbackErr := store.downloadTo(gcsFallbackURL+moduleKey, localPath)
+		if fallbackErr != nil {
+			return "", fmt.Errorf("failed to fetch from primary storage (%w) "+
+				"and GCS fallback (%w)", err, fallbackErr)
+		}
+	}
+
+	return localPath, nil
+}
+
+// downloadTo fetches the file at the given URL and atomically writes it to localPath.
+func (store *Store) downloadTo(url, localPath string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to request file: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		errorResponse, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("store returned %d %s", resp.StatusCode, errorResponse)
+		return fmt.Errorf("store returned %d %s", resp.StatusCode, errorResponse)
 	}
 
 	// Download the file to a temporary location to prevent half-complete modules on crashes.
 	file, err := os.CreateTemp(store.localCachePath, localTempPrefix)
 	if err != nil {
-		return "", fmt.Errorf("failed to create local file: %w", err)
+		return fmt.Errorf("failed to create local file: %w", err)
 	}
 	defer file.Close()
 	if _, err = io.Copy(file, resp.Body); err != nil {
-		return "", fmt.Errorf("failed to receive file: %w", err)
+		return fmt.Errorf("failed to receive file: %w", err)
 	}
 
-	if err = commitTempFile(file, localPath); err != nil {
-		return "", err
-	}
-
-	return localPath, nil
+	return commitTempFile(file, localPath)
 }
 
 // makeLocalPath creates the local cache path for the given ID.

--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -29,6 +29,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/readatbuf"
+	"go.opentelemetry.io/ebpf-profiler/tools/coredump/cloudstore"
 	zstpak "go.opentelemetry.io/ebpf-profiler/tools/zstpak/lib"
 )
 
@@ -42,9 +43,6 @@ const (
 	s3ResultsPerPage = 1000
 	// s3MaxPages defines the maximum number of pages to ever retrieve when listing objects.
 	s3MaxPages = 16
-	// gcsFallbackURL is the public read URL of the GCS bucket used as a fallback
-	// source for artifacts that are not available from the primary remote storage.
-	gcsFallbackURL = "https://storage.googleapis.com/parca-coredump-artifacts/"
 	// zstpakChunkSize determines the chunk size to use when compressing files.
 	zstpakChunkSize = 64 * 1024
 )
@@ -61,6 +59,7 @@ type Store struct {
 	s3client       *s3.Client
 	httpClient     *http.Client
 	publicReadURL  string
+	gcsFallbackURL string
 	bucket         string
 	localCachePath string
 }
@@ -80,6 +79,7 @@ func New(s3client *s3.Client, publicReadURL, s3Bucket, localCachePath string) (*
 		s3client:       s3client,
 		httpClient:     &http.Client{Transport: tr},
 		publicReadURL:  publicReadURL,
+		gcsFallbackURL: cloudstore.GCSPublicReadURL(),
 		bucket:         s3Bucket,
 		localCachePath: localCachePath,
 	}, nil
@@ -476,10 +476,13 @@ func (store *Store) ensurePresentLocally(id ID) (string, error) {
 	moduleKey := makeS3Key(id)
 	err = store.downloadTo(store.publicReadURL+moduleKey, localPath)
 	if err != nil {
-		// Fall back to the public GCS bucket before giving up.
+		// If a GCS fallback bucket is configured, try it before giving up.
+		if store.gcsFallbackURL == "" {
+			return "", err
+		}
 		log.Debugf("failed to fetch %s from primary storage (%v), trying GCS fallback",
 			id.String(), err)
-		fallbackErr := store.downloadTo(gcsFallbackURL+moduleKey, localPath)
+		fallbackErr := store.downloadTo(store.gcsFallbackURL+moduleKey, localPath)
 		if fallbackErr != nil {
 			return "", fmt.Errorf("failed to fetch from primary storage (%w) "+
 				"and GCS fallback (%w)", err, fallbackErr)

--- a/tools/coredump/upload.go
+++ b/tools/coredump/upload.go
@@ -48,6 +48,10 @@ func (cmd *uploadCmd) exec(context.Context, []string) (err error) {
 	}
 
 	if cmd.gcs {
+		if cloudstore.GCSBucket() == "" {
+			return fmt.Errorf("the -gcs flag requires the %s environment variable to be set",
+				cloudstore.GCSBucketEnvVar)
+		}
 		gcsClient, gerr := cloudstore.GCSClient()
 		if gerr != nil {
 			return fmt.Errorf("failed to create GCS client: %w", gerr)

--- a/tools/coredump/upload.go
+++ b/tools/coredump/upload.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 
+	"go.opentelemetry.io/ebpf-profiler/tools/coredump/cloudstore"
 	"go.opentelemetry.io/ebpf-profiler/tools/coredump/modulestore"
 )
 
@@ -22,6 +23,7 @@ type uploadCmd struct {
 	// User-specified command line arguments.
 	path string
 	all  bool
+	gcs  bool
 }
 
 func newUploadCmd(store *modulestore.Store) *ffcli.Command {
@@ -29,6 +31,8 @@ func newUploadCmd(store *modulestore.Store) *ffcli.Command {
 	set := flag.NewFlagSet("upload", flag.ExitOnError)
 	set.StringVar(&cmd.path, "path", "", "The path to a specific test case JSON")
 	set.BoolVar(&cmd.all, "all", false, "Upload all referenced modules for all test cases")
+	set.BoolVar(&cmd.gcs, "gcs", false,
+		"Upload to the public GCS bucket instead of the default remote storage")
 	return &ffcli.Command{
 		Name:       "upload",
 		ShortUsage: "upload [flags]",
@@ -41,6 +45,18 @@ func newUploadCmd(store *modulestore.Store) *ffcli.Command {
 func (cmd *uploadCmd) exec(context.Context, []string) (err error) {
 	if (cmd.all && cmd.path != "") || (!cmd.all && cmd.path == "") {
 		return errors.New("please pass either `-path` or `-all` (but not both)")
+	}
+
+	if cmd.gcs {
+		gcsClient, gerr := cloudstore.GCSClient()
+		if gerr != nil {
+			return fmt.Errorf("failed to create GCS client: %w", gerr)
+		}
+		cmd.store, err = modulestore.New(gcsClient,
+			cloudstore.GCSPublicReadURL(), cloudstore.GCSBucket(), "modulecache")
+		if err != nil {
+			return fmt.Errorf("failed to create GCS module store: %w", err)
+		}
 	}
 
 	var paths []string


### PR DESCRIPTION
Tests now fall back to the public gs://parca-coredump-artifacts bucket when an artifact is missing from the primary remote storage. The upload command gains a -gcs flag to push artifacts to that bucket instead.