### PR TITLE
gpu: per-function cubin PC samples via a single CUDAPCFrame + stall/SASS labels

### DIFF
--- a/interpreter/gpu/cuda.go
+++ b/interpreter/gpu/cuda.go
@@ -699,32 +699,38 @@ func emitPCSample(ev *CuptiPCSampleEvent, rep reporter.TraceReporter, cpuTrace *
 	}
 	// Transient: kernelName is interned (copied) before ev goes out of scope.
 	kernelName := pfunsafe.ToString(nullTerm(ev.FunctionName[:]))
+
+	// Decode the SASS instruction at this offset, surfaced as the
+	// "cuda_sass_instruction" sample label.
 	mnemonic := decodeInstruction(cubinInfo, kernelName, ev.Data.PCOffset)
+
+	// One mapping per cubin: the build ID is the cubin CRC (FileID with lo=0).
+	// The kernel's mangled name rides on the frame as its system name so the
+	// backend can resolve it per function.
 	cubinName := fmt.Sprintf("cubin-%016x", cubinInfo.CRC)
 	cubinMapping := libpf.NewFrameMapping(libpf.FrameMappingData{
 		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
-			FileID:     cubinInfo.FileID,
-			FileName:   libpf.Intern(cubinName),
-			GnuBuildID: fmt.Sprintf("%016x", cubinInfo.CRC),
+			FileID:   cubinInfo.FileID,
+			FileName: libpf.Intern(cubinName),
 		}),
 	})
 
-	count := ev.Data.StallReasonCount
-	if count > 64 {
-		count = 64
-	}
-	for i := uint64(0); i < count; i++ {
+	// One sample per stall reason: the same single CUDAPCFrame, distinguished by
+	// the "cuda_stall_reason" label and weighted by that reason's sample count.
+	count := min(ev.Data.StallReasonCount, maxStallReasons)
+	for i := range count {
 		sr := ev.StallReasons[i]
 		if sr.Samples == 0 {
 			continue
 		}
-		stallName := LookupStallReason(ev.Pid, sr.Index)
-		trace := buildGpuPCTrace(cpuTrace, cubinMapping, kernelName,
-			ev.Data.PCOffset, mnemonic, stallName, sr.Index)
+
+		trace := buildGpuPCTrace(cpuTrace, cubinMapping, kernelName, ev.Data.PCOffset)
+		trace.CustomLabels = gpuPCLabels(LookupStallReason(ev.Pid, sr.Index), mnemonic)
+
 		meta := buildGpuPCMeta(cpuTrace, ev.Pid, int64(sr.Samples))
 		trace.Hash = traceutil.HashTrace(trace)
 		if err := rep.ReportTraceEvent(trace, meta); err != nil {
-			log.Errorf("[cuda] failed to report deferred GPU PC sample: %v", err)
+			log.Errorf("[cuda] failed to report GPU PC sample: %v", err)
 		}
 	}
 }
@@ -867,10 +873,12 @@ func (f *gpuTraceFixer) maybeClear() fixerStats {
 }
 
 var (
-	cudaDevice libpf.String
-	cudaStream libpf.String
-	cudaGraph  libpf.String
-	cudaId     libpf.String
+	cudaDevice          libpf.String
+	cudaStream          libpf.String
+	cudaGraph           libpf.String
+	cudaId              libpf.String
+	cudaStallReason     libpf.String
+	cudaSassInstruction libpf.String
 )
 
 func init() {
@@ -878,6 +886,8 @@ func init() {
 	cudaStream = libpf.Intern("cuda_stream")
 	cudaGraph = libpf.Intern("cuda_graph")
 	cudaId = libpf.Intern("cuda_id")
+	cudaStallReason = libpf.Intern("cuda_stall_reason")
+	cudaSassInstruction = libpf.Intern("cuda_sass_instruction")
 }
 
 // nullTerm returns b truncated at the first NUL byte, or all of b if there is

--- a/interpreter/gpu/pcsampling.go
+++ b/interpreter/gpu/pcsampling.go
@@ -1,18 +1,15 @@
 package gpu // import "go.opentelemetry.io/ebpf-profiler/interpreter/gpu"
 
 import (
-	"fmt"
 	"time"
 	"unique"
 
 	log "github.com/sirupsen/logrus"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/support"
-	"go.opentelemetry.io/ebpf-profiler/traceutil"
 
 	sasstable "github.com/gnurizen/sass-table"
 )
@@ -25,20 +22,14 @@ const maxStallReasons = 64
 // mnemonic from the cubin's SASS code, and reports one gpupc trace per
 // non-zero stall reason.
 func HandlePCSample(ev *CuptiPCSampleEvent, rep reporter.TraceReporter) {
-	cubinInfo, ok := LoadCubin(ev.Data.CubinCRC)
-	if !ok {
+	if _, ok := LoadCubin(ev.Data.CubinCRC); !ok {
 		log.Debugf("[cuda] pc sample: cubin 0x%x not in cache, dropping", ev.Data.CubinCRC)
 		return
 	}
 
-	// Transient: kernelName is interned (copied) before ev goes out of scope.
-	kernelName := pfunsafe.ToString(nullTerm(ev.FunctionName[:]))
-
-	// Decode instruction mnemonic from cubin .text section.
-	mnemonic := decodeInstruction(cubinInfo, kernelName, ev.Data.PCOffset)
-
-	// Look up CPU trace for correlation. If found, emit immediately.
-	// If not, store for deferred resolution when the trace arrives.
+	// Correlate with a CPU trace. If the correlation trace hasn't arrived yet,
+	// stash this sample; it is emitted later via emitPCSample when the trace
+	// shows up.
 	var cpuTrace *SymbolizedCudaTrace
 	if ev.CorrelationID != 0 {
 		cpuTrace = LookupTraceForPCSample(libpf.PID(ev.Pid), ev.CorrelationID)
@@ -53,104 +44,40 @@ func HandlePCSample(ev *CuptiPCSampleEvent, rep reporter.TraceReporter) {
 		}
 	}
 
-	log.Debugf("[cuda] pc sample: pid=%d kernel=%q funcIdx=%d offset=0x%x mnemonic=%q corrID=%d stallReasons=%d cpuTrace=%v",
-		ev.Pid, kernelName, ev.Data.FunctionIndex, ev.Data.PCOffset, mnemonic, ev.CorrelationID,
-		ev.Data.StallReasonCount, cpuTrace != nil)
-
-	// Build cubin file mapping for the offset frame.
-	cubinName := fmt.Sprintf("cubin-%016x", cubinInfo.CRC)
-	cubinMapping := libpf.NewFrameMapping(libpf.FrameMappingData{
-		File: libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
-			FileID:   cubinInfo.FileID,
-			FileName: libpf.Intern(cubinName),
-		}),
-	})
-
-	count := min(ev.Data.StallReasonCount, maxStallReasons)
-
-	for i := range count {
-		sr := ev.StallReasons[i]
-		if sr.Samples == 0 {
-			continue
-		}
-
-		stallName := LookupStallReason(ev.Pid, sr.Index)
-		trace := buildGpuPCTrace(cpuTrace, cubinMapping, kernelName,
-			ev.Data.PCOffset, mnemonic, stallName, sr.Index)
-
-		meta := buildGpuPCMeta(cpuTrace, ev.Pid, int64(sr.Samples))
-
-		trace.Hash = traceutil.HashTrace(trace)
-		if err := rep.ReportTraceEvent(trace, meta); err != nil {
-			log.Errorf("[cuda] failed to report GPU PC sample: %v", err)
-		} else {
-			log.Debugf("[cuda] reported gpupc: kernel=%q offset=0x%x mnemonic=%q stall=%q stallIdx=%d samples=%d",
-				kernelName, ev.Data.PCOffset, mnemonic, stallName, sr.Index, sr.Samples)
-		}
-	}
+	emitPCSample(ev, rep, cpuTrace)
 }
 
-// buildGpuPCTrace constructs a trace with GPU PC sampling frames, optionally
-// prepended with CPU frames from the correlated trace.
+// buildGpuPCTrace constructs a trace for one GPU PC sample: a single
+// CUDAPCFrame carrying the function-relative offset, optionally followed by the
+// CPU frames from the correlated trace.
 //
-// Frame order (leaf to root):
-//
-//	[0] stall_reason  — CUDAKernelFrame
-//	[1] instruction   — CUDAKernelFrame (omitted if mnemonic is empty)
-//	[2] offset        — NativeFrame with cubin Mapping
-//	[3] kernel_name   — CUDAKernelFrame
-//	[4..N] CPU frames — from correlated trace (if available)
+// The GPU frame's mapping build ID is the cubin CRC (one mapping per cubin) and
+// the kernel's mangled name rides on it as the system name (in FunctionName),
+// so the backend resolves it per function to (kernel, file, line).
 func buildGpuPCTrace(cpuTrace *SymbolizedCudaTrace, cubinMapping libpf.FrameMapping,
-	kernelName string, pcOffset uint64, mnemonic string, stallName libpf.String,
-	stallIndex uint32) *libpf.Trace {
-
-	// Count GPU frames: kernel + offset + stall_reason, plus instruction if available.
-	gpuFrameCount := 3
-	if mnemonic != "" {
-		gpuFrameCount = 4
-	}
+	kernelName string, pcOffset uint64) *libpf.Trace {
 
 	// Count CPU frames (exclude the original CUDAKernelFrame).
 	cpuFrameCount := 0
 	if cpuTrace != nil {
-		cpuFrameCount = len(cpuTrace.Trace.Frames) - 1 // exclude CUDAKernelFrame
+		cpuFrameCount = len(cpuTrace.Trace.Frames) - 1
 		if cpuFrameCount < 0 {
 			cpuFrameCount = 0
 		}
 	}
 
 	trace := &libpf.Trace{
-		Frames: make(libpf.Frames, 0, gpuFrameCount+cpuFrameCount),
-	}
-
-	// GPU frames (leaf to root order).
-	// AddressOrLineno on the stall reason frame ensures HashTrace produces
-	// distinct hashes per stall reason (the hash only covers FileID + AddressOrLineno).
-	trace.Frames = append(trace.Frames, unique.Make(libpf.Frame{
-		Type:            libpf.CUDAKernelFrame,
-		FunctionName:    stallName,
-		AddressOrLineno: libpf.AddressOrLineno(stallIndex),
-	}))
-
-	if mnemonic != "" {
-		trace.Frames = append(trace.Frames, unique.Make(libpf.Frame{
-			Type:         libpf.CUDAKernelFrame,
-			FunctionName: libpf.Intern(mnemonic),
-		}))
+		Frames: make(libpf.Frames, 0, 1+cpuFrameCount),
 	}
 
 	trace.Frames = append(trace.Frames, unique.Make(libpf.Frame{
-		Type:            libpf.NativeFrame,
+		Type:            libpf.CUDAPCFrame,
+		FunctionName:    libpf.Intern(kernelName),
 		AddressOrLineno: libpf.AddressOrLineno(pcOffset),
 		Mapping:         cubinMapping,
 	}))
 
-	trace.Frames = append(trace.Frames, unique.Make(libpf.Frame{
-		Type:         libpf.CUDAKernelFrame,
-		FunctionName: libpf.Intern(kernelName),
-	}))
-
-	// CPU frames from correlated trace (skip the CUDAKernelFrame).
+	// CPU frames from the correlated trace (skip its CUDAKernelFrame).
 	if cpuTrace != nil {
 		for i, f := range cpuTrace.Trace.Frames {
 			if i == cpuTrace.CUDAFrameIdx {
@@ -161,6 +88,18 @@ func buildGpuPCTrace(cpuTrace *SymbolizedCudaTrace, cubinMapping libpf.FrameMapp
 	}
 
 	return trace
+}
+
+// gpuPCLabels builds the per-sample custom labels for a GPU PC sample: the CUPTI
+// stall reason and, when decoded, the SASS instruction mnemonic at the offset.
+func gpuPCLabels(stallName libpf.String, mnemonic string) map[libpf.String]libpf.String {
+	labels := map[libpf.String]libpf.String{
+		cudaStallReason: stallName,
+	}
+	if mnemonic != "" {
+		labels[cudaSassInstruction] = libpf.Intern(mnemonic)
+	}
+	return labels
 }
 
 // buildGpuPCMeta constructs TraceEventMeta for a gpupc sample.

--- a/libpf/frametype.go
+++ b/libpf/frametype.go
@@ -57,6 +57,11 @@ const (
 	LuaJITFrame FrameType = support.FrameMarkerLuaJIT
 	// CUDAKernelFrame identifies CUDA kernel frames.
 	CUDAKernelFrame FrameType = support.FrameMarkerCUDAKernel
+	// CUDAPCFrame identifies a CUDA PC-sample frame: a function-relative kernel
+	// offset that the backend resolves per-function. The kernel's mangled name
+	// rides in the frame's system name so the backend can key the per-function
+	// debuginfo lookup off it.
+	CUDAPCFrame FrameType = support.FrameMarkerCUDAPC
 )
 
 const (

--- a/libpf/interpretertype.go
+++ b/libpf/interpretertype.go
@@ -39,6 +39,8 @@ const (
 	BEAM InterpreterType = support.FrameMarkerBEAM
 	// CUDA interpreter type for CUDA kernels.
 	CUDA InterpreterType = support.FrameMarkerCUDAKernel
+	// CUDAPC interpreter type for CUDA PC-sample frames.
+	CUDAPC InterpreterType = support.FrameMarkerCUDAPC
 )
 
 // Pseudo-interpreters without a corresponding frame type.
@@ -80,6 +82,7 @@ var interpreterTypeToString = map[InterpreterType]string{
 	Dotnet:       "dotnet",
 	BEAM:         "beam",
 	CUDA:         "cuda",
+	CUDAPC:       "cuda-pc",
 	APMInt:       "apm-integration",
 	LuaJIT:       "luajit",
 	Go:           "go",

--- a/support/ebpf/frametypes.h
+++ b/support/ebpf/frametypes.h
@@ -37,6 +37,10 @@
 #define FRAME_MARKER_LUAJIT      0xD
 // Indicates a CUDA kernel frame
 #define FRAME_MARKER_CUDA_KERNEL 0xE
+// Indicates a CUDA PC-sample frame (a function-relative kernel offset that the
+// backend resolves per-function). Synthesized in user space, never emitted by
+// eBPF, but defined here to keep the marker space shared and consistent.
+#define FRAME_MARKER_CUDA_PC     0xF
 
 // Frame flags
 // Indicates that this frame is an error frame.

--- a/support/types.go
+++ b/support/types.go
@@ -25,6 +25,7 @@ const (
 	FrameMarkerLuaJIT     = 0xd
 	FrameMarkerBEAM       = 0xc
 	FrameMarkerCUDAKernel = 0xe
+	FrameMarkerCUDAPC     = 0xf
 	FrameMarkerGo         = 0xb
 )
 

--- a/support/types_def.go
+++ b/support/types_def.go
@@ -32,6 +32,7 @@ const (
 	FrameMarkerLuaJIT     = C.FRAME_MARKER_LUAJIT
 	FrameMarkerBEAM       = C.FRAME_MARKER_BEAM
 	FrameMarkerCUDAKernel = C.FRAME_MARKER_CUDA_KERNEL
+	FrameMarkerCUDAPC     = C.FRAME_MARKER_CUDA_PC
 	FrameMarkerGo         = C.FRAME_MARKER_GO
 )
 


### PR DESCRIPTION
Reworks how GPU PC samples are emitted so multi-kernel cubins can be symbolized per function while keeping **one mapping per cubin** (build_id = cubin CRC). The agent never derives a per-function build ID — the kernel name rides on the frame and the backend keys the per-function debuginfo lookup off it.

## Commits

**1. Single `CUDAPCFrame` per PC sample carrying the kernel name**

Replaces the old four-frame GPU trace (stall-reason + instruction + offset + kernel-name frames) with a single frame: the function-relative offset, whose mapping build_id is the cubin CRC and whose **system name** is the kernel's mangled name. The backend resolves it per function to `(kernel, file, line)`.

Adds a dedicated frame marker `FRAME_MARKER_CUDA_PC` (`0xf`) → `libpf.CUDAPCFrame` → frame-type string `"cuda-pc"`, so the backend gates per-function symbolization on the frame type rather than inferring it from the carrier shape. (`frametypes.h`, `types_def.go`, `types.go`, `frametype.go`, `interpretertype.go`.)

The immediate (`HandlePCSample`) and deferred (`emitPCSample`) paths are unified through one emit.

**2. Surface stall reason and SASS instruction as labels**

The stall reason and decoded SASS mnemonic are no longer frames — they become per-sample custom labels `cuda_stall_reason` and `cuda_sass_instruction`. One sample is emitted per stall reason (weighted by that reason's count); since `HashTrace` ignores labels, the labels distinguish samples without splitting the single-frame stacktrace. Label keys are interned once at init (matching the existing `cuda_device`/`cuda_stream`/… pattern in the same file).

## Notes

- `FRAME_MARKER_CUDA_PC` is synthesized in user space only; it's defined in the shared `frametypes.h` for consistency but is never emitted by eBPF.
- The backend (polarsignals) and the parca-agent reporter changes that consume the `"cuda-pc"` frame type and the kernel-name carrier are separate; this PR is the agent-side frame production.

Builds clean; `interpreter/gpu` tests pass.