### PR TITLE
upstream merge: fix metrics ids

### DIFF
--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -647,23 +647,23 @@ const (
 	// Number of failures to read TLS variables via the DTV
 	IDUnwindErrBadDTVRead = 286
 
-	// Number of failures to get TSD base for native custom labels
-	IDUnwindNativeCustomLabelsErrReadTsdBase = 287
+	// Number of cache hits for dotnet PE information
+	IDDotnetPEInfoCacheHit = 287
 
-	// Number of failures to read native custom labels thread-local object
-	IDUnwindNativeCustomLabelsErrReadData = 288
+	// Number of cache misses for dotnet PE information
+	IDDotnetPEInfoCacheMiss = 288
 
-	// Number of failures to read native custom labels key buffer
-	IDUnwindNativeCustomLabelsErrReadKey = 289
+	// Number of cache hits for dotnet #Strings heap lookups
+	IDDotnetStringsCacheHit = 289
 
-	// Number of failures to read native custom labels value buffer
-	IDUnwindNativeCustomLabelsErrReadValue = 290
+	// Number of cache misses for dotnet #Strings heap lookups
+	IDDotnetStringsCacheMiss = 290
 
-	// Number of successful reads of native custom labels
-	IDUnwindNativeCustomLabelsReadSuccesses = 291
+	// Number of bpf_ringbuf_output failures when sending trace events
+	IDBPFRingbufOutputErr = 291
 
-	// Total number of failures to add native custom labels
-	IDUnwindNativeCustomLabelsAddErrors = 292
+	// Number of cache hits for the dotnet PE open/parse error LRU
+	IDDotnetPEInfoErrCacheHit = 292
 
 	// Number of successes adding native custom labels
 	IDUnwindNativeCustomLabelsAddSuccesses = 293
@@ -713,23 +713,23 @@ const (
 	// Number of pending PC sample events dropped at retention-window eviction (correlation trace never arrived)
 	IDCudaPendingPCSamplesEvicted = 308
 
-	// Number of cache hits for dotnet PE information
-	IDDotnetPEInfoCacheHit = 309
+	// Number of failures to get TSD base for native custom labels
+	IDUnwindNativeCustomLabelsErrReadTsdBase = 309
 
-	// Number of cache misses for dotnet PE information
-	IDDotnetPEInfoCacheMiss = 310
+	// Number of failures to read native custom labels thread-local object
+	IDUnwindNativeCustomLabelsErrReadData = 310
 
-	// Number of cache hits for dotnet #Strings heap lookups
-	IDDotnetStringsCacheHit = 311
+	// Number of failures to read native custom labels key buffer
+	IDUnwindNativeCustomLabelsErrReadKey = 311
 
-	// Number of cache misses for dotnet #Strings heap lookups
-	IDDotnetStringsCacheMiss = 312
+	// Number of failures to read native custom labels value buffer
+	IDUnwindNativeCustomLabelsErrReadValue = 312
 
-	// Number of bpf_ringbuf_output failures when sending trace events
-	IDBPFRingbufOutputErr = 313
+	// Number of successful reads of native custom labels
+	IDUnwindNativeCustomLabelsReadSuccesses = 313
 
-	// Number of cache hits for the dotnet PE open/parse error LRU
-	IDDotnetPEInfoErrCacheHit = 314
+	// Total number of failures to add native custom labels
+	IDUnwindNativeCustomLabelsAddErrors = 314
 
 	// max number of ID values, keep this as *last entry*
 	IDMax = 315

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -2099,45 +2099,45 @@
     "id": 286
   },
   {
-    "description": "Number of failures to get TSD base for native custom labels",
+    "description": "Number of cache hits for dotnet PE information",
     "type": "counter",
-    "name": "UnwindNativeCustomLabelsErrReadTsdBase",
-    "field": "bpf.native_custom_labels.errors.read_tsd_base",
+    "name": "DotnetPEInfoCacheHit",
+    "field": "agent.dotnet.pe_info_cache.hits",
     "id": 287
   },
   {
-    "description": "Number of failures to read native custom labels thread-local object",
+    "description": "Number of cache misses for dotnet PE information",
     "type": "counter",
-    "name": "UnwindNativeCustomLabelsErrReadData",
-    "field": "bpf.native_custom_labels.errors.read_data",
+    "name": "DotnetPEInfoCacheMiss",
+    "field": "agent.dotnet.pe_info_cache.misses",
     "id": 288
   },
   {
-    "description": "Number of failures to read native custom labels key buffer",
+    "description": "Number of cache hits for dotnet #Strings heap lookups",
     "type": "counter",
-    "name": "UnwindNativeCustomLabelsErrReadKey",
-    "field": "bpf.native_custom_labels.errors.read_key",
+    "name": "DotnetStringsCacheHit",
+    "field": "agent.dotnet.strings_cache.hits",
     "id": 289
   },
   {
-    "description": "Number of failures to read native custom labels value buffer",
+    "description": "Number of cache misses for dotnet #Strings heap lookups",
     "type": "counter",
-    "name": "UnwindNativeCustomLabelsErrReadValue",
-    "field": "bpf.native_custom_labels.errors.read_value",
+    "name": "DotnetStringsCacheMiss",
+    "field": "agent.dotnet.strings_cache.misses",
     "id": 290
   },
   {
-    "description": "Number of successful reads of native custom labels",
+    "description": "Number of bpf_ringbuf_output failures when sending trace events",
     "type": "counter",
-    "name": "UnwindNativeCustomLabelsReadSuccesses",
-    "field": "bpf.native_custom_labels.read.successes",
+    "name": "BPFRingbufOutputErr",
+    "field": "bpf.errors.ringbuf_output",
     "id": 291
   },
   {
-    "description": "Total number of failures to add native custom labels",
+    "description": "Number of cache hits for the dotnet PE open/parse error LRU",
     "type": "counter",
-    "name": "UnwindNativeCustomLabelsAddErrors",
-    "field": "bpf.native_custom_labels.add.errors",
+    "name": "DotnetPEInfoErrCacheHit",
+    "field": "agent.dotnet.pe_info_err_cache.hits",
     "id": 292
   },
   {
@@ -2253,45 +2253,45 @@
     "id": 308
   },
   {
-    "description": "Number of cache hits for dotnet PE information",
+    "description": "Number of failures to get TSD base for native custom labels",
     "type": "counter",
-    "name": "DotnetPEInfoCacheHit",
-    "field": "agent.dotnet.pe_info_cache.hits",
+    "name": "UnwindNativeCustomLabelsErrReadTsdBase",
+    "field": "bpf.native_custom_labels.errors.read_tsd_base",
     "id": 309
   },
   {
-    "description": "Number of cache misses for dotnet PE information",
+    "description": "Number of failures to read native custom labels thread-local object",
     "type": "counter",
-    "name": "DotnetPEInfoCacheMiss",
-    "field": "agent.dotnet.pe_info_cache.misses",
+    "name": "UnwindNativeCustomLabelsErrReadData",
+    "field": "bpf.native_custom_labels.errors.read_data",
     "id": 310
   },
   {
-    "description": "Number of cache hits for dotnet #Strings heap lookups",
+    "description": "Number of failures to read native custom labels key buffer",
     "type": "counter",
-    "name": "DotnetStringsCacheHit",
-    "field": "agent.dotnet.strings_cache.hits",
+    "name": "UnwindNativeCustomLabelsErrReadKey",
+    "field": "bpf.native_custom_labels.errors.read_key",
     "id": 311
   },
   {
-    "description": "Number of cache misses for dotnet #Strings heap lookups",
+    "description": "Number of failures to read native custom labels value buffer",
     "type": "counter",
-    "name": "DotnetStringsCacheMiss",
-    "field": "agent.dotnet.strings_cache.misses",
+    "name": "UnwindNativeCustomLabelsErrReadValue",
+    "field": "bpf.native_custom_labels.errors.read_value",
     "id": 312
   },
   {
-    "description": "Number of bpf_ringbuf_output failures when sending trace events",
+    "description": "Number of successful reads of native custom labels",
     "type": "counter",
-    "name": "BPFRingbufOutputErr",
-    "field": "bpf.errors.ringbuf_output",
+    "name": "UnwindNativeCustomLabelsReadSuccesses",
+    "field": "bpf.native_custom_labels.read.successes",
     "id": 313
   },
   {
-    "description": "Number of cache hits for the dotnet PE open/parse error LRU",
+    "description": "Total number of failures to add native custom labels",
     "type": "counter",
-    "name": "DotnetPEInfoErrCacheHit",
-    "field": "agent.dotnet.pe_info_err_cache.hits",
+    "name": "UnwindNativeCustomLabelsAddErrors",
+    "field": "bpf.native_custom_labels.add.errors",
     "id": 314
   }
 ]


### PR DESCRIPTION

Upstream PRs #1430, #1431, and #1339 claimed IDs 287–292 (dotnet PE caches, dotnet error LRU, ringbuf output). During the merge I had pushed those to 309–314 instead of letting them keep their authoritative values. Final commit swaps them back: upstream metrics own 287–292; parca's `native_custom_labels` error/success counters move to 309–314. BPF metricID enum positions are unchanged, so `MetricsTranslation` and the BPF blobs are untouched.

Going forward we should keep the convention "parca-only metrics live past upstream's IDMax" so future merges don't collide.

## Outstanding

- `#1519` (Comm type to avoid eager interning) landed upstream after this branch; not included here. Will fold into the next cycle.
- Rust crate `rust-crates/symblib-capi/go` still needs `cargo build` before `go build ./...` succeeds. Pre-existing.

## Verification

- `make ebpf` and `make ebpf TARGET_ARCH=arm64` clean.
- `CGO_ENABLED=1 go build ./...` clean (excluding `rust-crates/symblib-capi`).
- `CGO_ENABLED=1 go vet ./...` only flags pre-existing warnings (`luajit.go:482` unreachable, `tools/coredump/ebpfhelpers.go` unsafe.Pointer misuse, `processinfo_test.go` unkeyed fields).

## Tooling notes

This cycle was driven by `tools/upstream-merge.sh` iteratively: each invocation merged the maximal auto-resolvable prefix, stopped at the next conflict, I hand-resolved + committed, then re-ran the script with the new HEAD as `ORIGIN_REF`. Two things made the script much more useful than last cycle:

1. `git config rerere.autoUpdate true` so rerere'd files get auto-staged — without it the script bails out on every rerere-resolved file as "not auto-resolvable" and we'd need to hand-stage each one.
2. Re-invoking the script after each manual resolution lets it binary-search forward through the unmerged commits and batch the next clean prefix (typical batch sizes this cycle: 7, 8, 12, 25 commits).

Both worth folding into the script proper so the next person doesn't have to rediscover them.