### PR TITLE
tools: track upstream-merge.sh + add playbook

### DIFF
--- a/tools/upstream-merge-playbook.md
+++ b/tools/upstream-merge-playbook.md
@@ -1,0 +1,199 @@
+# Upstream merge playbook
+
+This is the operator's manual for `tools/upstream-merge.sh`. The script handles
+the easy parts (binary-searching for the maximal clean prefix, rebuilding BPF
+blobs, accepting upstream's `go.mod`/`go.sum`). This document covers the bits
+you have to bring: how to drive the script iteratively, what to look for at
+each stopping point, and the parca-specific decisions that come up nearly every
+cycle.
+
+## When to use
+
+Each upstream merge cycle: bring `parca-dev/opentelemetry-ebpf-profiler`'s
+`main` up to a recent `open-telemetry/opentelemetry-ebpf-profiler` `main`,
+landing as a single PR with one merge commit per resolved batch.
+
+## Quick start
+
+Start in a clean worktree on `origin/main`:
+
+```bash
+git fetch upstream
+git checkout -b <some-tmp-branch> origin/main
+tools/upstream-merge.sh --no-smoke
+```
+
+The script creates `upstream-merge`, binary-searches the unmerged upstream
+commits, merges the maximal auto-resolvable prefix, and stops before the
+first conflict it can't handle. Stopping output looks like:
+
+```
+>>> Branch upstream-merge: merged 12 of 127 upstream commits
+!!! Stopped before: 64a21c56 bpf: rename field offtime to value (#1369)
+!!! 115 commit(s) remain and need manual attention
+```
+
+Resolve that one commit by hand (see the decision matrix below), commit, then
+drive the script forward by pointing `ORIGIN_REF` at the new HEAD:
+
+```bash
+git branch -D progress 2>/dev/null
+git checkout -b progress
+git branch -D upstream-merge
+tools/upstream-merge.sh --no-fetch --no-smoke upstream/main progress
+```
+
+Loop until `git log upstream/main ^HEAD` is empty.
+
+`--no-smoke` is recommended because the smoke test (`make test`) is slow and
+its failures usually point at Go-side breakage caused by an earlier merge that
+needs a follow-up, not at the merge currently being probed. Run `make test`
+once at the end instead.
+
+## What the script auto-resolves
+
+Three things, all listed in the BPF/go.mod regexes near the top of the script:
+
+- `support/ebpf/tracer.ebpf.{amd64,arm64}` — take `theirs`, then rebuild from
+  the merged C sources.
+- `go.mod` / `go.sum` — take `theirs`, then `go mod tidy`.
+- Anything else where rerere has cached a clean resolution from a prior run.
+
+The third one is why `rerere.enabled` and `rerere.autoUpdate` must both be on.
+The script sets them with `--local` during preflight, but it's worth knowing
+why: `autoUpdate=false` leaves rerere-resolved files in `UU` state, so
+`all_auto_resolvable` rejects them as non-auto-resolvable and the script bails
+on what would otherwise be a clean batch.
+
+## Per-stop checklist
+
+When the script stops, the workflow at each stop is the same:
+
+1. `git merge --no-commit --no-edit <next-sha>` — see what conflicts come up.
+2. Resolve each conflicting file (see decision matrix).
+3. `git checkout --theirs support/ebpf/tracer.ebpf.{amd64,arm64}` and
+   `make -C support/ebpf amd64 && make -C support/ebpf arm64`.
+4. If `metrics/metrics.json` changed: `go generate ./metrics/...`.
+5. If `support/types_def.go` changed: `(cd support && ./generate.sh)` and copy
+   `types_gen.go` over `types.go`. Never edit `support/types.go` directly.
+6. `git add -u` and verify with `CGO_ENABLED=1 go vet ./tracer ./support ...`
+   (the packages touched by the merge).
+7. Commit with `git -c user.email=... -c user.name='...' commit -s --no-edit`
+   to preserve the auto-generated `Merge commit '<sha>' into upstream-merge`
+   message. **No `Co-Authored-By: Claude` trailers** — this repo follows the
+   OTel community policy of human-only attribution.
+
+## Decision matrix for recurring conflicts
+
+These show up every cycle. Defaults assume the parca fork's behavior should
+survive unless noted.
+
+### `support/ebpf/tracemgmt.h`
+
+- **`RATELIMIT_ACTION_NONE` early-return** — always keep. The dlopen-uprobe
+  path depends on it; merging it into upstream's `RATELIMIT_ACTION_RESET`
+  early-return block (one combined `||`) is the canonical resolution.
+- **`normalize_pac_ptr` definition** — parca keeps the canonical definition
+  near the top of the file; if upstream relocates or duplicates it, accept
+  upstream's relocation and verify there's still only one definition.
+- **`increment_metric` definition** — parca has it in `support/ebpf/util.h`,
+  not `tracemgmt.h`. When upstream adds it to `tracemgmt.h` as part of an
+  unrelated relocation patch, drop their addition; keep ours in `util.h`.
+
+### `support/ebpf/native_stack_trace.{ebpf.c,h}`
+
+Parca split the body of `native_stack_trace.ebpf.c` out into the `.h`. When
+upstream modifies the `.ebpf.c` body:
+
+- Take `--ours` on `native_stack_trace.ebpf.c` (the file is essentially
+  `#include "native_stack_trace.h"` now).
+- Apply upstream's actual content changes to the corresponding place in
+  `native_stack_trace.h`.
+
+### `support/ebpf/types.h` — `UnwindState` register slots
+
+Parca keeps `r14` on x86_64 (LuaJIT DISPATCH register). When upstream
+adds/removes other slots (`rdi`/`r8` for vfork support, etc.), merge their
+additions but keep `r14`.
+
+### `metrics/metrics.json` and `metrics/ids.go`
+
+Edit `metrics.json`; never hand-edit `ids.go`. Run `go generate ./metrics/...`
+to regenerate.
+
+**Metric ID policy**: parca-only metric IDs always live past upstream's IDMax.
+When upstream lands new metrics that collide with parca's range, the upstream
+metrics keep their authoritative IDs and parca's get renumbered to come after
+them. Then `jq --indent 2 'sort_by(.id)' metrics/metrics.json` to keep the
+file in ID order. The BPF `metricID_*` C enum positions don't change in this
+swap — `MetricsTranslation` maps slot → Go symbol, not slot → Go value, so no
+BPF blob rebuild is needed.
+
+### `support/types_def.go` ↔ `support/types.go`
+
+`types.go` is generated from `types_def.go` via cgo godefs. Edit
+`types_def.go` for any C-enum additions, then:
+
+```bash
+(cd support && ./generate.sh)   # diffs generated vs current
+cp support/types_gen.go support/types.go   # if the diff is what you wanted
+rm -rf support/_obj support/types_gen.go
+```
+
+### Upstream "upstreams" of parca PRs
+
+When upstream lands a PR that originally came from parca (custom labels,
+dlopen-uprobe, python+native combo, fix-stale-go-label, native r28 fallback),
+prefer the parca-fork version of the file — it usually has post-review
+refinements upstream didn't pick up. Skip upstream's additions if parca has
+the equivalent elsewhere (e.g. `go_support.h::get_go_m_ptr` already covers
+`go_get_*` from upstream #1456).
+
+### Rename cascades
+
+Upstream periodically renames things parca code participates in. The recurring
+ones so far:
+
+- `off_cpu_time → value` (#1369): also rename `TraceMeta.OffTime → Value` in
+  `interpreter/gpu/`.
+- `ReadVirtualMemory → ReadAt` (#1384): parca's nodev8 has extra call sites
+  upstream's PR doesn't touch.
+- Perf reader → ringbuf reader (#1339): drop `TraceBufferSizeMultiplier`
+  (perf-specific) and `lostEventsCount`; `loadBpfTrace` no longer takes a
+  `CPU` arg.
+- `Trace.Hash` removed (#1518): drop explicit `traceutil.HashTrace` calls;
+  `maybeNotifyAPMAgent` takes `*libpf.Trace` directly.
+
+When in doubt: grep parca-only files (`interpreter/gpu/`, `interpreter/cuda*`,
+`interpreter/customlabels/`, `interpreter/oomwatcher/`) for the old name.
+
+## Filing the PR
+
+Branch name convention: `upstream-merge-<NNNN>` where `NNNN` is the highest
+upstream PR number included.
+
+PR title: `upstream merge: N merges through #NNNN [+ ...]`.
+
+PR body should call out:
+- Notable upstream PRs folded in and what parca-side surgery they required.
+- Any metric ID renumbering done this cycle.
+- Outstanding upstream commits that landed after the branch was cut.
+- Pre-existing vet/build issues that aren't caused by the merge.
+
+## Things that have been wrong before
+
+A list of mistakes from prior cycles so future-you can recognize them:
+
+- **Pushing upstream's new metric IDs to the end of the range instead of
+  parca's.** Always: upstream owns the lower IDs, parca's stuff goes at the
+  end past upstream's IDMax.
+- **Editing `support/types.go` directly** instead of `types_def.go`. The
+  generator's diff will tell you, but only after you've made the wrong edit.
+- **Forgetting `git config rerere.autoUpdate true`.** The script now sets
+  this, but if you're resolving by hand outside the script, do the same.
+- **Putting `Co-Authored-By: Claude` or "Generated with Claude Code" in PR
+  bodies.** OTel-adjacent repos don't take AI attribution. The user is the
+  author.
+- **Running `git merge upstream/main` once and trying to resolve everything in
+  one merge commit.** The script's batching produces a cleaner history and is
+  way more debuggable when something breaks.

--- a/tools/upstream-merge.sh
+++ b/tools/upstream-merge.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+#
+# upstream-merge.sh — keep origin/main up to date with upstream/main
+#
+# Finds the merge base, identifies all upstream commits past it, and
+# merges the largest prefix that doesn't require human intervention.
+# After merging, a smoke test is run to verify the result; if it fails
+# the script binary-searches for the last commit that passes.
+#
+# Auto-resolvable conflicts:
+#   * support/ebpf/tracer.ebpf.{amd64,arm64} — rebuilt from merged sources
+#   * go.mod / go.sum — accept upstream, then `go mod tidy`
+#
+# Everything else is considered a "real" conflict and the script stops
+# before it, leaving you with the largest clean merge possible.
+#
+# Usage:
+#   tools/upstream-merge.sh [options] [upstream-ref] [origin-ref]
+#
+# Options:
+#   --no-fetch   Skip 'git fetch' (useful when you already fetched)
+#   --no-smoke   Skip the post-merge smoke test
+#   -h, --help   Show this help
+#
+# Defaults: upstream/main and origin/main.
+
+set -euo pipefail
+
+# ── smoke-test commands ────────────────────────────────────────────────
+# All must pass for a merge to be accepted.  Add more entries as needed.
+
+SMOKE_CMDS=(
+    "go test -run ^$ ./..."
+    "make test"
+)
+
+# ── defaults & arg parsing ─────────────────────────────────────────────
+
+UPSTREAM_REF="upstream/main"
+ORIGIN_REF="origin/main"
+DO_FETCH=true
+DO_SMOKE=true
+
+args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-fetch)  DO_FETCH=false; shift ;;
+        --no-smoke)  DO_SMOKE=false; shift ;;
+        -h|--help)   sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)           args+=("$1"); shift ;;
+    esac
+done
+if [[ ${#args[@]} -ge 1 ]]; then UPSTREAM_REF="${args[0]}"; fi
+if [[ ${#args[@]} -ge 2 ]]; then ORIGIN_REF="${args[1]}"; fi
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+log()  { printf '\033[1;34m>>>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERR\033[0m %s\n' "$*" >&2; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_DIR="$(git rev-parse --git-dir)"
+
+BPF_BLOB_RE='^support/ebpf/tracer\.ebpf\.(amd64|arm64)$'
+GOMOD_RE='^go\.(mod|sum)$'
+
+# Print paths of unmerged (conflicting) files, one per line.
+unmerged_files() {
+    git diff --name-only --diff-filter=U
+}
+
+# Return 0 if every conflicting file is one we know how to auto-resolve.
+all_auto_resolvable() {
+    local f count=0
+    while IFS= read -r f; do
+        [[ "$f" =~ $BPF_BLOB_RE || "$f" =~ $GOMOD_RE ]] || return 1
+        ((count++))
+    done < <(unmerged_files)
+    # Must have at least one conflict to be "resolvable" (not an empty set).
+    [[ $count -gt 0 ]]
+}
+
+# Ensure the repo is in a clean, non-merging state.  Aggressively
+# removes stale lock files that a failed merge may leave behind.
+reset_merge_state() {
+    rm -f "$GIT_DIR/index.lock"
+    git merge --abort 2>/dev/null || git reset --merge 2>/dev/null || true
+    rm -f "$GIT_DIR/index.lock"
+}
+
+# Non-destructive merge probe: attempt the merge, check whether it's
+# clean or auto-resolvable, then roll back.  Returns 0 = mergeable.
+probe_merge() {
+    local sha="$1"
+    if git merge --no-commit --no-edit "$sha" >/dev/null 2>&1; then
+        reset_merge_state
+        return 0
+    fi
+    local rc=1
+    all_auto_resolvable && rc=0
+    reset_merge_state
+    return "$rc"
+}
+
+# Binary-search for the index of the last commit where probe_merge
+# succeeds.  Prints the index to stdout, or -1 if none.
+find_last_clean() {
+    local lo=0 hi=$(($1 - 1)) result=-1 mid
+    while [[ $lo -le $hi ]]; do
+        mid=$(( (lo + hi) / 2 ))
+        printf '\r  probing %d/%d …' "$((mid + 1))" "$1" >&2
+        if probe_merge "${COMMITS[$mid]}"; then
+            result=$mid
+            lo=$((mid + 1))
+        else
+            hi=$((mid - 1))
+        fi
+    done
+    printf '\n' >&2
+    echo "$result"
+}
+
+# Resolve auto-resolvable conflicts in the working tree and commit.
+# Uses explicit || return 1 so this is safe to call from condition
+# contexts (e.g. inside an `if`) where set -e is suppressed.
+auto_resolve() {
+    local has_bpf=false has_gomod=false f
+    local -a conflicts
+    mapfile -t conflicts < <(unmerged_files)
+
+    for f in "${conflicts[@]}"; do
+        case "$f" in
+            support/ebpf/tracer.ebpf.*) has_bpf=true  ;;
+            go.mod|go.sum)              has_gomod=true ;;
+        esac
+    done
+
+    # ── go.mod / go.sum ────────────────────────────────────────────────
+    if $has_gomod; then
+        log "  go.mod/go.sum → accept upstream + go mod tidy"
+        git checkout --theirs -- go.mod                              || return 1
+        git checkout --theirs -- go.sum 2>/dev/null || true
+        ( cd "$REPO_ROOT" && go mod tidy )                           || return 1
+        git add go.mod go.sum                                        || return 1
+    fi
+
+    # ── BPF blobs ──────────────────────────────────────────────────────
+    if $has_bpf; then
+        log "  BPF blobs → rebuilding from merged sources"
+        for f in "${conflicts[@]}"; do
+            case "$f" in
+                support/ebpf/tracer.ebpf.*)
+                    git checkout --theirs -- "$f"                    || return 1
+                    git add "$f"                                     || return 1
+                    ;;
+            esac
+        done
+        make -C "$REPO_ROOT/support/ebpf" amd64                     || return 1
+        make -C "$REPO_ROOT/support/ebpf" arm64                     || return 1
+        git add support/ebpf/tracer.ebpf.amd64 \
+               support/ebpf/tracer.ebpf.arm64                       || return 1
+    fi
+
+    # Annotate the merge commit message.
+    local merge_msg="$GIT_DIR/MERGE_MSG"
+    if [[ -f "$merge_msg" ]]; then
+        {
+            cat "$merge_msg"
+            echo ""
+            echo "Auto-resolved:"
+            if $has_gomod; then echo "  - go.mod/go.sum: accepted upstream, ran go mod tidy"; fi
+            if $has_bpf;   then echo "  - BPF blobs: rebuilt from merged C sources"; fi
+        } > "${merge_msg}.tmp"
+        mv "${merge_msg}.tmp" "$merge_msg"
+    fi
+
+    git commit --no-edit                                             || return 1
+}
+
+# Run every command in SMOKE_CMDS.  Returns 0 only if all pass.
+run_smoke() {
+    local cmd
+    for cmd in "${SMOKE_CMDS[@]}"; do
+        log "  smoke: $cmd"
+        if ! ( cd "$REPO_ROOT" && eval "$cmd" ); then
+            return 1
+        fi
+    done
+}
+
+# Reset the branch to ORIGIN_HEAD and merge the given sha (with
+# auto-resolve if needed).  Returns 0 on success.  On failure the
+# branch is reset back to ORIGIN_HEAD.
+merge_from_base() {
+    local sha="$1"
+    git reset --hard "$ORIGIN_HEAD" >/dev/null 2>&1
+
+    if git merge --no-edit "$sha" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [[ -f "$GIT_DIR/MERGE_HEAD" ]] && all_auto_resolvable; then
+        if auto_resolve; then
+            return 0
+        fi
+        reset_merge_state
+    else
+        reset_merge_state
+    fi
+    git reset --hard "$ORIGIN_HEAD" >/dev/null 2>&1
+    return 1
+}
+
+# ── preflight ──────────────────────────────────────────────────────────
+
+[[ -z "$(git status --porcelain --untracked-files=no)" ]] || die "Working tree is dirty; commit or stash first"
+
+# rerere makes this script meaningfully better: when we resolve a conflict by
+# hand and rerun, the next probe replays that resolution. autoUpdate is what
+# stages it — without it the file shows up as UU and all_auto_resolvable
+# rejects the whole batch, so the script bails on conflicts it could have
+# carried through. Set both with --local so we don't touch global config.
+git config --local rerere.enabled true
+git config --local rerere.autoUpdate true
+
+if $DO_FETCH; then
+    log "Fetching remotes…"
+    git fetch origin
+    git fetch upstream
+fi
+
+BASE=$(git merge-base "$ORIGIN_REF" "$UPSTREAM_REF")
+log "Merge base: $(git log --oneline -1 "$BASE")"
+
+mapfile -t COMMITS < <(git rev-list --reverse "$BASE..$UPSTREAM_REF")
+TOTAL=${#COMMITS[@]}
+if [[ $TOTAL -eq 0 ]]; then
+    log "Already up to date with $UPSTREAM_REF."
+    exit 0
+fi
+log "$TOTAL upstream commit(s) to consider"
+
+# Save where we came from so we can get back on failure.
+ORIGINAL_REF=$(git symbolic-ref --quiet HEAD 2>/dev/null || git rev-parse HEAD)
+
+# Create a working branch rooted at origin/main.
+BRANCH="upstream-merge"
+git checkout -b "$BRANCH" "$ORIGIN_REF"
+log "Working on branch $BRANCH"
+
+ORIGIN_HEAD=$(git rev-parse HEAD)
+
+# Clean-up helper: abort any in-progress merge on unexpected exit.
+cleanup() {
+    local rc=$?
+    if [[ $rc -ne 0 ]] && [[ -f "$GIT_DIR/MERGE_HEAD" ]]; then
+        warn "Aborting in-progress merge due to error"
+        reset_merge_state
+    fi
+    return "$rc"
+}
+trap cleanup EXIT
+
+# ── phase 1: find the furthest conflict-clean commit ──────────────────
+
+LAST_CLEAN=-1
+
+# Optimistic: try the tip first — avoids scanning when everything merges.
+if probe_merge "${COMMITS[$((TOTAL - 1))]}"; then
+    LAST_CLEAN=$((TOTAL - 1))
+    log "Full merge with $UPSTREAM_REF is conflict-clean (or auto-resolvable)"
+else
+    log "Full merge has non-resolvable conflicts; binary-searching…"
+    LAST_CLEAN=$(find_last_clean "$TOTAL")
+fi
+
+if [[ $LAST_CLEAN -lt 0 ]]; then
+    warn "Even the first upstream commit has non-resolvable conflicts:"
+    warn "  $(git log --oneline -1 "${COMMITS[0]}")"
+    if git merge --no-commit --no-edit "${COMMITS[0]}" >/dev/null 2>&1; then
+        reset_merge_state
+    else
+        warn "Conflicting files:"
+        unmerged_files | while IFS= read -r f; do
+            [[ "$f" =~ $BPF_BLOB_RE || "$f" =~ $GOMOD_RE ]] && continue
+            warn "  $f"
+        done
+        reset_merge_state
+    fi
+    git checkout "${ORIGINAL_REF#refs/heads/}" 2>/dev/null || git checkout "$ORIGINAL_REF"
+    git branch -D "$BRANCH"
+    exit 1
+fi
+
+TARGET="${COMMITS[$LAST_CLEAN]}"
+log "Furthest conflict-clean commit: $(git log --oneline -1 "$TARGET")"
+
+# ── phase 2: merge the candidate ─────────────────────────────────────
+
+if git merge --no-edit "$TARGET"; then
+    log "Merged cleanly"
+elif [[ -f "$GIT_DIR/MERGE_HEAD" ]]; then
+    log "Auto-resolving conflicts…"
+    auto_resolve
+    log "Auto-resolved and committed"
+else
+    die "git merge failed unexpectedly"
+fi
+
+# ── phase 3: smoke test ──────────────────────────────────────────────
+
+LAST_GOOD=$LAST_CLEAN
+
+if $DO_SMOKE; then
+    log "Running smoke tests…"
+    if run_smoke; then
+        log "Smoke tests passed"
+    else
+        warn "Smoke tests failed after merging $((LAST_CLEAN + 1)) commit(s)"
+
+        if [[ $LAST_CLEAN -eq 0 ]]; then
+            warn "Even the first upstream commit fails smoke; giving up"
+            git reset --hard "$ORIGIN_HEAD" >/dev/null 2>&1
+            git checkout "${ORIGINAL_REF#refs/heads/}" 2>/dev/null || git checkout "$ORIGINAL_REF"
+            git branch -D "$BRANCH"
+            exit 1
+        fi
+
+        log "Binary-searching for the last commit that passes smoke…"
+        lo=0 hi=$((LAST_CLEAN - 1)) smoke_good=-1
+        while [[ $lo -le $hi ]]; do
+            mid=$(( (lo + hi) / 2 ))
+            short=$(git rev-parse --short "${COMMITS[$mid]}")
+            log "  smoke-probing $((mid + 1))/$((LAST_CLEAN + 1)) ($short)…"
+
+            if merge_from_base "${COMMITS[$mid]}" && run_smoke; then
+                smoke_good=$mid
+                lo=$((mid + 1))
+            else
+                hi=$((mid - 1))
+            fi
+        done
+
+        if [[ $smoke_good -lt 0 ]]; then
+            warn "No upstream commits pass the smoke tests"
+            git reset --hard "$ORIGIN_HEAD" >/dev/null 2>&1
+            git checkout "${ORIGINAL_REF#refs/heads/}" 2>/dev/null || git checkout "$ORIGINAL_REF"
+            git branch -D "$BRANCH"
+            exit 1
+        fi
+
+        # Land on the winning merge.
+        merge_from_base "${COMMITS[$smoke_good]}"
+        LAST_GOOD=$smoke_good
+        log "Smoke tests pass with $((smoke_good + 1)) commit(s)"
+
+        FIRST_BAD="${COMMITS[$((smoke_good + 1))]}"
+        warn "First commit that breaks smoke: $(git log --oneline -1 "$FIRST_BAD")"
+    fi
+fi
+
+# ── summary ────────────────────────────────────────────────────────────
+
+MERGED=$((LAST_GOOD + 1))
+log "Branch $BRANCH: merged $MERGED of $TOTAL upstream commits"
+if [[ $MERGED -lt $TOTAL ]]; then
+    NEXT="${COMMITS[$((LAST_GOOD + 1))]}"
+    warn "Stopped before: $(git log --oneline -1 "$NEXT")"
+    warn "$((TOTAL - MERGED)) commit(s) remain and need manual attention"
+    exit 1
+fi
+log "Fully merged with $UPSTREAM_REF"


### PR DESCRIPTION
The script has been living untracked in \`tools/upstream-merge.sh\` for several merge cycles. Track it now, alongside a playbook that captures the operator's manual.

## \`tools/upstream-merge.sh\`

Mostly the script as it's been running locally, with one preflight tweak: the script now sets \`rerere.enabled\` and \`rerere.autoUpdate\` to \`true\` (\`--local\`) on every run.

Without \`autoUpdate\`, rerere-resolved files end up in \`UU\` state, \`all_auto_resolvable\` rejects the whole batch, and the script bails on conflicts it would otherwise carry through. The failure mode is opaque (\"Even the first upstream commit has non-resolvable conflicts\" on what's actually just a tracemgmt.h rerere hit). We rediscovered this in the cycle that produced #302. Easier to just set it.

\`--local\` keeps the change scoped to this repo.

## \`tools/upstream-merge-playbook.md\`

First version. Covers:

- The iterative loop pattern (drive the script, hand-resolve at stops, re-invoke with the new HEAD as \`ORIGIN_REF\`).
- What the script auto-resolves and why \`rerere.autoUpdate\` matters.
- Per-stop checklist (probe, resolve, rebuild blobs, regenerate ids/types, vet, commit).
- Decision matrix for the conflicts that recur every cycle: \`RATELIMIT_ACTION_NONE\` keepalive, \`native_stack_trace\` header split, \`UnwindState\` x86 r14 preservation, metric ID policy, \`types_def.go\` ↔ \`types.go\` generation flow, the parca-PR-upstreamed pattern, recurring rename cascades.
- Metric ID policy made explicit: parca-only IDs live past upstream's IDMax; when upstream lands new ones that collide, swap and reorder with \`jq sort_by(.id)\`.
- A short \"things that have been wrong before\" list so future-you can recognize past mistakes.

This is a first version pulled from the in-flight knowledge of the cycle that produced #302; it'll need updates next cycle when new patterns surface.