### PR TITLE
processmanager: remove TraceInterceptor extension point

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -64,8 +64,7 @@ var (
 func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInterval time.Duration,
 	executableUnloadDelay time.Duration, ebpf pmebpf.EbpfHandler, traceReporter reporter.TraceReporter,
 	exeReporter reporter.ExecutableReporter, sdp nativeunwind.StackDeltaProvider,
-	filterErrorFrames bool, includeEnvVars libpf.Set[string],
-	interceptor TraceInterceptor) (*ProcessManager, error) {
+	filterErrorFrames bool, includeEnvVars libpf.Set[string]) (*ProcessManager, error) {
 	if exeReporter == nil {
 		exeReporter = executableReporterStub{}
 	}
@@ -113,7 +112,6 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		frameCache:               frameCache,
 		traceReporter:            traceReporter,
 		exeReporter:              exeReporter,
-		interceptor:              interceptor,
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        filterErrorFrames,
 		includeEnvVars:           includeEnvVars,
@@ -420,10 +418,6 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 		}
 	}
 	pm.mu.RUnlock()
-
-	if pm.interceptor != nil && pm.interceptor(trace, meta) {
-		return
-	}
 
 	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace, 1)
 

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -18,7 +18,6 @@ import (
 	pmebpf "go.opentelemetry.io/ebpf-profiler/processmanager/ebpfapi"
 	eim "go.opentelemetry.io/ebpf-profiler/processmanager/execinfomanager"
 	"go.opentelemetry.io/ebpf-profiler/reporter"
-	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
 	"go.opentelemetry.io/ebpf-profiler/times"
 	"go.opentelemetry.io/ebpf-profiler/util"
 )
@@ -40,14 +39,6 @@ type frameCacheKey struct {
 	// data is the frame data: frame header and the two first variable fields
 	data [3]uint64
 }
-
-// TraceInterceptor is called after symbolization with the symbolized trace
-// and metadata. Return true to consume the trace, in which case HandleTrace
-// skips its default reporting path; return false to let HandleTrace report
-// the trace normally. Consumers that need to report intercepted traces are
-// expected to do so via their own TraceReporter — the hook is intentionally
-// a one-way handoff, not a passthrough callback.
-type TraceInterceptor func(trace *libpf.Trace, meta *samples.TraceEventMeta) bool
 
 // ProcessManager is responsible for managing the events happening throughout the lifespan of a
 // process.
@@ -106,10 +97,6 @@ type ProcessManager struct {
 
 	// traceReporter is the interface to report traces
 	traceReporter reporter.TraceReporter
-
-	// interceptor, if set, is called after symbolization.
-	// If it returns true the trace is consumed and not reported.
-	interceptor TraceInterceptor
 
 	// exeReporter is the interface to report executables
 	exeReporter reporter.ExecutableReporter
@@ -178,9 +165,4 @@ type processInfo struct {
 // GetEbpfHandler returns the EbpfHandler interface for direct access to eBPF operations.
 func (pm *ProcessManager) GetEbpfHandler() pmebpf.EbpfHandler {
 	return pm.ebpf
-}
-
-// SetInterceptor sets an interceptor to be used for traces
-func (pm *ProcessManager) SetInterceptor(interceptor TraceInterceptor) {
-	pm.interceptor = interceptor
 }

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -173,7 +173,7 @@ func ExtractTraces(ctx context.Context, pr process.Process, debug bool,
 
 	manager, err := pm.New(todo, includeTracers, monitorInterval, executableUnloadDelay,
 		&coredumpEbpfMaps, &traceReporter, nil, elfunwindinfo.NewStackDeltaProvider(),
-		false, libpf.Set[string]{}, nil)
+		false, libpf.Set[string]{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Interpreter manager: %v", err)
 	}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -272,7 +272,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	processManager, err := pm.New(ctx, cfg.IncludeTracers, cfg.Intervals.MonitorInterval(),
 		cfg.Intervals.ExecutableUnloadDelay(), ebpfHandler, cfg.TraceReporter, cfg.ExecutableReporter,
 		elfunwindinfo.NewStackDeltaProvider(),
-		cfg.FilterErrorFrames, cfg.IncludeEnvVars, nil)
+		cfg.FilterErrorFrames, cfg.IncludeEnvVars)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}
@@ -1369,8 +1369,4 @@ func (t *Tracer) GetInterpretersForPID(pid libpf.PID) []interpreter.Instance {
 // pidEvents channel. Used to speed up tests.
 func (t *Tracer) ForceProcessPID(pid libpf.PID) {
 	t.pidEvents <- libpf.PIDTID(uint64(pid) + uint64(pid)<<32)
-}
-
-func (t *Tracer) SetInterceptor(interceptor pm.TraceInterceptor) {
-	t.processManager.SetInterceptor(interceptor)
 }


### PR DESCRIPTION
Drop the TraceInterceptor type, the ProcessManager.interceptor field, the
SetInterceptor methods on ProcessManager and Tracer, and the interceptor
parameter on pm.New. The interceptor was previously used by parcagpu in
parca-agent to divert CUDA traces after symbolization; parcagpu has since
moved to wrapping reporter.TraceReporter directly, which makes the
interceptor extension point dead code here.
