### PR TITLE
collector/config: replace xconfmap with confmap

### DIFF
--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 }
 
 // Validate validates the config.
-// This is automatically called by the config parser as it implements the xconfmap.Validator interface.
+// This is automatically called by the config parser as it implements the confmap.Validator interface.
 func (cfg *Config) Validate() error {
 	if cfg.ErrorMode != IgnoreError && cfg.ErrorMode != PropagateError {
 		return fmt.Errorf("unknown error mode %q", cfg.ErrorMode)

--- a/collector/config/config_test.go
+++ b/collector/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap/xconfmap"
+	"go.opentelemetry.io/collector/confmap"
 )
 
 // validConfig returns a config with valid defaults for testing.
@@ -26,7 +26,7 @@ func TestValidate(t *testing.T) {
 		SamplesPerSecond: 0,
 		ErrorMode:        PropagateError,
 	}
-	err := xconfmap.Validate(cfg)
+	err := confmap.Validate(cfg)
 	require.Error(t, err)
 	require.Equal(t, "invalid sampling frequency: 0", err.Error())
 }
@@ -103,7 +103,7 @@ func TestValidateErrorMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.ErrorMode = tt.errorMode
-			err := xconfmap.Validate(cfg)
+			err := confmap.Validate(cfg)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	go.opentelemetry.io/collector/component v1.61.0
 	go.opentelemetry.io/collector/component/componenttest v0.155.0
 	go.opentelemetry.io/collector/confmap v1.61.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.155.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.155.0
 	go.opentelemetry.io/collector/consumer/xconsumer v0.155.0
 	go.opentelemetry.io/collector/pdata v1.61.0

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ go.opentelemetry.io/collector/component/componenttest v0.155.0 h1:FfQQpYJnkNhNW5
 go.opentelemetry.io/collector/component/componenttest v0.155.0/go.mod h1:MkXnGN4QH6El1GGTTOrDUqY8/p8Vkbfi0Non2Pmi0m4=
 go.opentelemetry.io/collector/confmap v1.61.0 h1:LkSQF8tt3eyYTK+sW4d4ub2T0SjUwwzxAt7dJnfKFHs=
 go.opentelemetry.io/collector/confmap v1.61.0/go.mod h1:OmuazWMkNuAwJr5BMuloacsNrW9ES458VHjVfLB0B78=
-go.opentelemetry.io/collector/confmap/xconfmap v0.155.0 h1:tJ8UbfRsG7Owqfixr3n3Jq6os1Qk50ZCUUPtBXpXT7w=
-go.opentelemetry.io/collector/confmap/xconfmap v0.155.0/go.mod h1:Px/cVCKxPtca92c0p0SzztHuS+bXSavH3CQS06GeEoo=
 go.opentelemetry.io/collector/consumer v1.61.0 h1:yMmN7wAN/wwkUPVvu/Lt3aRmoLoo1YxROrZXgrHUydk=
 go.opentelemetry.io/collector/consumer v1.61.0/go.mod h1:JrP1TChChplqMfswPgz7UQmUIU+KKHVyV69k2oMbUA4=
 go.opentelemetry.io/collector/consumer/consumererror v0.155.0 h1:vy/Psno5X+VYv6kfsJDCD7Gn5mUJOi9CR3AuT5fYoRA=


### PR DESCRIPTION
The "Collector Tests" workflow clones the Collector repo and injects a `replace` directive, so it builds against Collector **tip** rather than the version pinned in `go.mod`. `xconfmap.Validate` no longer exists there:

```
collector/config/config_test.go:29:18: undefined: xconfmap.Validate
collector/config/config_test.go:106:20: undefined: xconfmap.Validate
```

The job has been failing on `main` every day for over a week as a result.

`confmap.Validate` is present in the pinned `confmap v1.61.0` as well as at tip, so switching fixes the workflow without affecting the pinned build.

## Relationship to upstream

This is a forward-port of upstream #1715 (`8e548577`, "collector/config: replace xconfmap with confmap"), not a cherry-pick. That commit could not be applied directly: its version of `config_test.go` also touches `FrameCacheSize`, `TargetCPUIDs` and `FilterMinProcessAge`, which come from upstream changes (#1588, #1429, #1501) that this fork has not merged yet. The substance is identical, so #1715 should merge as a no-op when it arrives in sequence.

Found while reviewing CI on #325 (upstream merge through #1567). This failure is independent of that merge, hence the separate PR.

## Verification

`go test ./collector/...` passes.
